### PR TITLE
Implement Schema Methods

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -433,8 +433,9 @@ public class BQConnection implements Connection {
         throw new BQSQLException("Not implemented.");
     }
 
-    public String getSchema() throws SQLException {
-        throw new BQSQLException("Not implemented.");
+    @Override
+    public String getSchema() {
+        return this.dataset;
     }
 
     public void abort(Executor executor) throws SQLException {
@@ -539,7 +540,7 @@ public class BQConnection implements Connection {
     }
 
     /**
-     * Getter method for projectid
+     * Getter method for projectId
      */
     public String getProjectId() {
         return this.projectId;

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -429,8 +429,9 @@ public class BQConnection implements Connection {
                 + "createStruct(string,object[])");
     }
 
-    public void setSchema(String schema) throws SQLException {
-        throw new BQSQLException("Not implemented.");
+    @Override
+    public void setSchema(String schema) {
+        this.dataset = schema;
     }
 
     @Override

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -117,6 +117,46 @@ public class QueryResultTest {
     }
 
     @Test
+    public void QueryResultTestWithDataset() throws SQLException {
+        NewConnection("&useLegacySql=false");
+
+        QueryResultTest.con.setSchema("foobar");
+        Assert.assertEquals("foobar", QueryResultTest.con.getSchema());
+
+        QueryResultTest.con.setSchema("tokyo_star");
+        Assert.assertEquals("tokyo_star", QueryResultTest.con.getSchema());
+
+        final String sql = "SELECT meaning FROM meaning_of_life GROUP BY ROLLUP(meaning);";
+        String[][] expectation = new String[][]{ {null, "42"} };
+
+        this.logger.info("Test Tokyo number: 1");
+        this.logger.info("Running query:" + sql);
+
+        java.sql.ResultSet Result = null;
+        try {
+            Statement s = QueryResultTest.con.createStatement();
+            s.setMaxRows(1);
+            Result = s.executeQuery(sql);
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail("SQLException" + e.toString());
+        }
+        Assert.assertNotNull(Result);
+
+        HelperFunctions.printer(expectation);
+
+        try {
+            String[][] res = BQSupportMethods.GetQueryResult(Result);
+            Assert.assertTrue(
+                "Comparing failed in the String[][] array " + Arrays.deepToString(res),
+                this.comparer(expectation, res));
+        } catch (SQLException e) {
+            this.logger.error("SQLexception" + e.toString());
+            Assert.fail(e.toString());
+        }
+    }
+
+    @Test
     public void QueryResultTest01() {
         final String sql = "SELECT TOP(word, 10), COUNT(*) FROM publicdata:samples.shakespeare";
         final String description = "The top 10 word from shakespeare #TOP #COUNT";


### PR DESCRIPTION
Some `dbcp2` expects `(get|set)Scehma` to work if a schema is set on the connection, here we implement.


From `dbcp2`:
![image](https://user-images.githubusercontent.com/12849602/97219059-b7b3c300-1786-11eb-8be3-f53af2a77485.png)
