### PR TITLE
Remove support for Catalog -> ProjectId name mangling

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQDatabaseMetadata.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQDatabaseMetadata.java
@@ -293,7 +293,7 @@ class BQDatabaseMetadata implements DatabaseMetaData {
                 String[] Data = new String[Projects.size()];
                 String toLog = "";
                 for (int i = 0; i < Projects.size(); i++) {
-                    Data[i] = Projects.get(i).getId().replace(":", "__").replace(".", "_");
+                    Data[i] = Projects.get(i).getId();
                     toLog += Data[i] + " , ";
                 }
                 logger.debug("Catalogs are: " + toLog);
@@ -402,11 +402,17 @@ class BQDatabaseMetadata implements DatabaseMetaData {
                 (columnNamePattern != null ? columnNamePattern : "null"));
         List<Table> Tables = null;
         try {
-            Tables = BQSupportFuncts.getTables(this.Connection, catalog,
-                    schemaPattern, tableNamePattern);
+            Tables = BQSupportFuncts.getTables(
+                this.Connection,
+                CatalogName.toProjectId(catalog),
+                schemaPattern,
+                tableNamePattern);
             if (Tables == null) { //Because of Crystal Reports It's not elegant, but hey it works!
-                Tables = BQSupportFuncts.getTables(this.Connection, schemaPattern,
-                        catalog, tableNamePattern);
+                Tables = BQSupportFuncts.getTables(
+                    this.Connection,
+                    CatalogName.toProjectId(schemaPattern),
+                    catalog,
+                    tableNamePattern);
             }
         } catch (IOException e) {
             throw new BQSQLException(e);
@@ -415,13 +421,9 @@ class BQDatabaseMetadata implements DatabaseMetaData {
         if (Tables != null) {
             List<String[]> data = new ArrayList<String[]>();
             for (int i = 0; i < Tables.size(); i++) {
-                String UparsedId = Tables.get(i).getId();
-                String ProjectId = BQSupportFuncts
-                        .getProjectIdFromAnyGetId(UparsedId).replace(":", "__").replace(".", "_");
-                String DatasetId = BQSupportFuncts
-                        .getDatasetIdFromTableDotGetId(UparsedId);
-                String TableId = BQSupportFuncts
-                        .getTableIdFromTableDotGetId(UparsedId);
+                String ProjectId = Tables.get(i).getTableReference().getProjectId();
+                String DatasetId = Tables.get(i).getTableReference().getDatasetId();
+                String TableId = Tables.get(i).getTableReference().getTableId();
 
                 List<TableFieldSchema> tblfldschemas = Tables.get(i)
                         .getSchema().getFields();
@@ -1404,10 +1406,8 @@ class BQDatabaseMetadata implements DatabaseMetaData {
                     data = new String[datasetlist.size()][2];
                     int i = 0;
                     for (Datasets datasets : datasetlist) {
-                        data[i][0] = datasets.getDatasetReference()
-                                .getDatasetId();
-                        data[i][1] = datasets.getDatasetReference()
-                                .getProjectId().replace(".", "_").replace(":", "__");
+                        data[i][0] = datasets.getDatasetReference().getDatasetId();
+                        data[i][1] = datasets.getDatasetReference().getProjectId();
                         i++;
                     }
                 }
@@ -1482,10 +1482,8 @@ class BQDatabaseMetadata implements DatabaseMetaData {
                     data = new String[datasetlist.size()][2];
                     i = 0;
                     for (Datasets datasets : datasetlist) {
-                        String schema = datasets.getDatasetReference()
-                                .getDatasetId();
-                        String projnm = datasets.getDatasetReference()
-                                .getProjectId();
+                        String schema = datasets.getDatasetReference().getDatasetId();
+                        String projnm = datasets.getDatasetReference().getProjectId();
                         logger.debug("We search for catalog/project: " + catalog);
                         if ((schema.equals(schemaPattern) || schemaPattern == null)
                                 && (projnm.equals(catalog) || catalog == null)) {
@@ -1744,11 +1742,17 @@ class BQDatabaseMetadata implements DatabaseMetaData {
                 + ", types: " + typesToLog + ")");
         List<Table> tables = null;
         try {
-            tables = BQSupportFuncts.getTables(this.Connection, catalog,
-                    schemaPattern, tableNamePattern);
+            tables = BQSupportFuncts.getTables(
+                this.Connection,
+                CatalogName.toProjectId(catalog),
+                schemaPattern,
+                tableNamePattern);
             if (tables == null) { //because of crystal reports, It's not elegant but hey, it works!
-                tables = BQSupportFuncts.getTables(this.Connection, tableNamePattern,
-                        schemaPattern, catalog);
+                tables = BQSupportFuncts.getTables(
+                    this.Connection,
+                    CatalogName.toProjectId(tableNamePattern),
+                    schemaPattern,
+                    catalog);
             }
         } catch (IOException e) {
             throw new BQSQLException(e);
@@ -1757,16 +1761,15 @@ class BQDatabaseMetadata implements DatabaseMetaData {
             logger.debug("got result, size: " + tables.size());
             String[][] data = new String[tables.size()][10];
             for (int i = 0; i < tables.size(); i++) {
-                String UparsedId = tables.get(i).getId();
-                data[i][0] = BQSupportFuncts.getProjectIdFromAnyGetId(UparsedId).replace(":", "__").replace(".", "_");
-                data[i][1] = BQSupportFuncts.getDatasetIdFromTableDotGetId(UparsedId);
-                data[i][2] = BQSupportFuncts.getTableIdFromTableDotGetId(UparsedId);
+                data[i][0] = tables.get(i).getTableReference().getProjectId();
+                data[i][1] = tables.get(i).getTableReference().getDatasetId();
+                data[i][2] = tables.get(i).getTableReference().getTableId();
                 data[i][3] = "TABLE";
                 data[i][4] = tables.get(i).getDescription();
                 data[i][5] = null;
-                data[i][6] = BQSupportFuncts.getProjectIdFromAnyGetId(UparsedId).replace(":", "__").replace(".", "_");
-                data[i][7] = BQSupportFuncts.getDatasetIdFromTableDotGetId(UparsedId);
-                data[i][8] = BQSupportFuncts.getTableIdFromTableDotGetId(UparsedId);
+                data[i][6] = tables.get(i).getTableReference().getProjectId();
+                data[i][7] = tables.get(i).getTableReference().getDatasetId();
+                data[i][8] = tables.get(i).getTableReference().getTableId();
                 data[i][9] = null;
             }
             return new DMDResultSet(data, new String[]{"TABLE_CAT",

--- a/src/main/java/net/starschema/clouddb/jdbc/BQPreparedStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQPreparedStatement.java
@@ -72,7 +72,7 @@ public class BQPreparedStatement extends BQStatementRoot implements
         this.logger.debug("Constructor of PreparedStatement Running " +
                 "projectid is:" + projectid + "sqlquery: " + querysql);
 
-        this.ProjectId = projectid;
+        this.projectId = projectid;
         this.connection = bqConnection;
         //this.resultSetType = ResultSet.TYPE_SCROLL_INSENSITIVE;  //-scrollable
         this.resultSetType = ResultSet.TYPE_FORWARD_ONLY;
@@ -116,7 +116,7 @@ public class BQPreparedStatement extends BQStatementRoot implements
                     "The Resultset Concurrency can't be ResultSet.CONCUR_UPDATABLE");
         }
 
-        this.ProjectId = projectid;
+        this.projectId = projectid;
         this.connection = bqConnection;
         this.resultSetType = resultSetType;
         this.resultSetConcurrency = resultSetConcurrency;
@@ -238,7 +238,7 @@ public class BQPreparedStatement extends BQStatementRoot implements
             // Gets the Job reference of the completed job with give Query
             referencedJob = BQSupportFuncts.startQuery(
                     this.connection.getBigquery(),
-                    this.ProjectId.replace("__", ":").replace("_", "."),
+                    this.projectId,
                     this.RunnableStatement,
                     this.connection.getDataSet(),
                     this.connection.getUseLegacySql(),
@@ -252,17 +252,17 @@ public class BQPreparedStatement extends BQStatementRoot implements
             do {
                 if (BQSupportFuncts.getQueryState(referencedJob,
                         this.connection.getBigquery(),
-                        this.ProjectId.replace("__", ":").replace("_", "."))
+                        this.projectId)
                         .equals("DONE")) {
                     if (resultSetType == ResultSet.TYPE_SCROLL_INSENSITIVE) {
                         return new BQScrollableResultSet(BQSupportFuncts.getQueryResults(
                                 this.connection.getBigquery(),
-                                this.ProjectId.replace("__", ":").replace("_", "."),
+                                this.projectId,
                                 referencedJob), this);
                     } else {
                         return new BQForwardOnlyResultSet(
                                 this.connection.getBigquery(),
-                                this.ProjectId.replace("__", ":").replace("_", "."),
+                                this.projectId,
                                 referencedJob, this);
                     }
                 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -59,12 +59,12 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     /**
      * Constructor for BQStatement object just initializes local variables
      *
-     * @param projectid
+     * @param projectId
      * @param bqConnection
      */
-    public BQStatement(String projectid, BQConnection bqConnection) {
-        logger.debug("Constructor of BQStatement is running projectid is: " + projectid);
-        this.ProjectId = projectid;
+    public BQStatement(String projectId, BQConnection bqConnection) {
+        logger.debug("Constructor of BQStatement is running projectId is: " + projectId);
+        this.projectId = projectId;
         this.connection = bqConnection;
         this.resultSetType = ResultSet.TYPE_FORWARD_ONLY;
         this.resultSetConcurrency = ResultSet.CONCUR_READ_ONLY;
@@ -73,15 +73,15 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     /**
      * Constructor for BQStatement object just initializes local variables
      *
-     * @param projectid
+     * @param projectId
      * @param bqConnection
      * @param resultSetType
      * @param resultSetConcurrency
      * @throws BQSQLException
      */
-    public BQStatement(String projectid, BQConnection bqConnection,
+    public BQStatement(String projectId, BQConnection bqConnection,
                        int resultSetType, int resultSetConcurrency) throws BQSQLException {
-        logger.debug("Constructor of BQStatement is running projectid is: " + projectid +
+        logger.debug("Constructor of BQStatement is running projectId is: " + projectId +
                 ",resultSetType is: " + resultSetType +
                 ",resutSetConcurrency is: " + resultSetConcurrency);
         if (resultSetConcurrency == ResultSet.CONCUR_UPDATABLE) {
@@ -89,7 +89,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                     "The Resultset Concurrency can't be ResultSet.CONCUR_UPDATABLE");
         }
 
-        this.ProjectId = projectid;
+        this.projectId = projectId;
         this.connection = bqConnection;
         this.resultSetType = resultSetType;
         this.resultSetConcurrency = resultSetConcurrency;
@@ -146,14 +146,14 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                     null :
                     this.connection.getBigquery()
                             .jobs()
-                            .get(this.ProjectId, qr.getJobReference().getJobId())
+                            .get(projectId, qr.getJobReference().getJobId())
                             .setLocation(qr.getJobReference().getLocation())
                             .execute();
             if (qr.getJobComplete()) {
                 if (resultSetType != ResultSet.TYPE_SCROLL_INSENSITIVE) {
                     return new BQForwardOnlyResultSet(
                             this.connection.getBigquery(),
-                            this.ProjectId.replace("__", ":").replace("_", "."),
+                            projectId,
                             referencedJob, this, qr.getRows(), fetchedAll, qr.getSchema());
                 } else if (fetchedAll) {
                     // We can only return scrollable result sets here if we have all the rows: otherwise we'll
@@ -180,7 +180,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                     try {
                         status = BQSupportFuncts.getQueryState(referencedJob,
                                 this.connection.getBigquery(),
-                                this.ProjectId.replace("__", ":").replace("_", "."));
+                                projectId);
                     } catch (IOException e) {
                         if (retries++ < MAX_IO_FAILURE_RETRIES) {
                             continue;
@@ -196,12 +196,12 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                     if (resultSetType == ResultSet.TYPE_SCROLL_INSENSITIVE) {
                         return new BQScrollableResultSet(BQSupportFuncts.getQueryResults(
                                 this.connection.getBigquery(),
-                                this.ProjectId.replace("__", ":").replace("_", "."),
+                                projectId,
                                 referencedJob), this);
                     } else {
                         return new BQForwardOnlyResultSet(
                                 this.connection.getBigquery(),
-                                this.ProjectId.replace("__", ":").replace("_", "."),
+                                projectId,
                                 referencedJob, this);
                     }
                 }
@@ -241,7 +241,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
             try {
                 QueryResponse resp = BQSupportFuncts.runSyncQuery(
                         this.connection.getBigquery(),
-                        this.ProjectId,
+                        projectId,
                         querySql,
                         connection.getDataSet(),
                         this.connection.getUseLegacySql(),
@@ -324,7 +324,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
 
     /** Wrap [BQSupportFuncts.cancelQuery] purely for testability purposes. */
     protected void performQueryCancel(JobReference jobRefToCancel) throws IOException {
-        BQSupportFuncts.cancelQuery(jobRefToCancel, this.connection.getBigquery(), this.ProjectId.replace("__", ":").replace("_", "."));
+        BQSupportFuncts.cancelQuery(jobRefToCancel, this.connection.getBigquery(), projectId);
     }
 
     @Override

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -50,7 +50,7 @@ public abstract class BQStatementRoot {
     ResultSet resset = null;
 
     /** String containing the context of the Project */
-    String ProjectId = null;
+    String projectId = null;
 
     Logger logger = LoggerFactory.getLogger(BQStatementRoot.class);
 
@@ -257,7 +257,7 @@ public abstract class BQStatementRoot {
         try {
             QueryResponse qr = BQSupportFuncts.runSyncQuery(
                     this.connection.getBigquery(),
-                    this.ProjectId,
+                    projectId,
                     sql,
                     connection.getDataSet(),
                     this.connection.getUseLegacySql(),
@@ -271,7 +271,7 @@ public abstract class BQStatementRoot {
                 return Math.toIntExact(qr.getNumDmlAffectedRows());
             }
 
-            referencedJob = this.connection.getBigquery().jobs().get(this.ProjectId, qr.getJobReference().getJobId()).execute();
+            referencedJob = this.connection.getBigquery().jobs().get(projectId, qr.getJobReference().getJobId()).execute();
         } catch (IOException e) {
             throw new BQSQLException("Something went wrong with the query: " + sql, e);
         }
@@ -279,11 +279,11 @@ public abstract class BQStatementRoot {
         try {
             do {
                 if (BQSupportFuncts.getQueryState(referencedJob,
-                        this.connection.getBigquery(), this.ProjectId).equals(
+                        this.connection.getBigquery(), projectId).equals(
                         "DONE")) {
                     return Math.toIntExact(
                                 BQSupportFuncts.getQueryResults(
-                                        this.connection.getBigquery(), this.ProjectId,
+                                        this.connection.getBigquery(), projectId,
                                         referencedJob).getNumDmlAffectedRows()
                             );
                 }
@@ -314,7 +314,7 @@ public abstract class BQStatementRoot {
         try {
             QueryResponse qr = BQSupportFuncts.runSyncQuery(
                     this.connection.getBigquery(),
-                    this.ProjectId,
+                    projectId,
                     querySql,
                     connection.getDataSet(),
                     this.connection.getUseLegacySql(),
@@ -328,7 +328,7 @@ public abstract class BQStatementRoot {
                 }
                 jobAlreadyCompleted = true;
             }
-            referencedJob = this.connection.getBigquery().jobs().get(this.ProjectId, qr.getJobReference().getJobId()).execute();
+            referencedJob = this.connection.getBigquery().jobs().get(projectId, qr.getJobReference().getJobId()).execute();
 
             this.logger.info("Executing Query: " + querySql);
         } catch (IOException e) {
@@ -337,16 +337,16 @@ public abstract class BQStatementRoot {
         try {
             do {
                 if (jobAlreadyCompleted || BQSupportFuncts.getQueryState(referencedJob,
-                        this.connection.getBigquery(), this.ProjectId).equals(
+                        this.connection.getBigquery(), projectId).equals(
                         "DONE")) {
                     if (resultSetType == ResultSet.TYPE_SCROLL_INSENSITIVE) {
                         return new BQScrollableResultSet(BQSupportFuncts.getQueryResults(
-                                this.connection.getBigquery(), this.ProjectId,
+                                this.connection.getBigquery(), projectId,
                                 referencedJob), this);
                     } else {
                         return new BQForwardOnlyResultSet(
                                 this.connection.getBigquery(),
-                                this.ProjectId.replace("__", ":").replace("_", "."),
+                                projectId,
                                 referencedJob, this);
                     }
                 }

--- a/src/main/java/net/starschema/clouddb/jdbc/CatalogName.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/CatalogName.java
@@ -1,0 +1,23 @@
+package net.starschema.clouddb.jdbc;
+
+/**
+ * Utility class to translate between JDBC Catalog names and BigQuery Project Ids.
+ *
+ * <p>This is primarily here to maintain compatibility with older versions of this driver which
+ * accepted an encoded version of the ProjectId as the Catalog name. So as not to break existing
+ * clients, we will still accept this encoding as part of the JDBC URL identifier.
+ *
+ * <p>The encoding affects Projects which are prefixed with a domain, such as
+ * "looker.com:sample-project". These may be selected with a Catalog name of
+ * "looker_com__sample-project", where the period (`.`) is replaced wih a single underscore (`_`)
+ * and the colon (`:`) is replaced with two underscores (`__`).
+ */
+public final class CatalogName {
+    public static String toProjectId(String encodedCatalogName) {
+        if (encodedCatalogName == null) {
+            return null;
+        } else {
+            return encodedCatalogName.replace("__", ":").replace("_", ".");
+        }
+    }
+}

--- a/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/CancelTest.java
@@ -154,8 +154,8 @@ public class CancelTest {
     }
 
     private static class TestableBQStatement extends BQStatement {
-        public TestableBQStatement(String projectid, BQConnection bqConnection) {
-            super(projectid, bqConnection);
+        public TestableBQStatement(String projectId, BQConnection bqConnection) {
+            super(projectId, bqConnection);
         }
         private Condition testPoint;
         private Lock testLock;

--- a/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
@@ -40,11 +40,23 @@ public class JdbcUrlTest {
 
     @Test
     public void projectWithColons() throws SQLException {
-        String urlWithColonContainingProject = URL.replace(bq.getProjectId(), "before:after");
+        String urlWithColonContainingProject = URL.replace(bq.getProjectId(), "example.com:project");
         try {
-            BQConnection bq_with_colons = new BQConnection(urlWithColonContainingProject, new Properties());
-            // Some day we'll get rid of the whacky subbing in and out of colons with double underscores, but today is not that day
-            Assert.assertEquals("before__after", bq_with_colons.getProjectId());
+            BQConnection bqWithColons = new BQConnection(urlWithColonContainingProject, new Properties());
+            Assert.assertEquals("example.com:project", bqWithColons.getProjectId());
+            Assert.assertEquals("example.com:project", bqWithColons.getCatalog());
+        } catch (SQLException e){
+            fail("failed to get or parse url: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void mungedProjectName() throws SQLException {
+        String urlWithUnderscoreContainingProject = URL.replace(bq.getProjectId(), "example_com__project");
+        try {
+            BQConnection bqWithUnderscores = new BQConnection(urlWithUnderscoreContainingProject, new Properties());
+            Assert.assertEquals("example.com:project", bqWithUnderscores.getProjectId());
+            Assert.assertEquals("example.com:project", bqWithUnderscores.getCatalog());
         } catch (SQLException e){
             fail("failed to get or parse url: " + e.getMessage());
         }


### PR DESCRIPTION
A prior version of this driver supported translating between SQL-92 and
BigQuery Legacy dialects.  As part of this support, it would mangle
BigQuery Project Ids like `looker.com:sample-project` to
`looker_com__sample-project`.  We found that there were some bugs in
this translation leading to the mangled name being sent to BigQuery when
the real ProjectId should have been sent.

We recently removed support for this translation between dialects.
Since we no longer require that, we can now remove most of the code
which did the name mangling.

In this PR, we fix on using the Project Id internally as much as
possible.  Only in public methods of the JDBC API do we accept a Catalog
name.  All internal methods translate this to a Project Id before doing
any further processing of them.

We do retain one vestige of the original name mangling.  We continue to
support the mangled names in the JDBC URI.  This is to maintain
compatibility with an existing configurations which used the mangled
name.  Should we decide to drop this support in the future, it should be
trivial now that all of the mangling is contained in the single
`CatalogName.toProjectId` method.