### PR TITLE
Fixup NaN values in double types

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -215,18 +215,17 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
     /** Parse floating point types */
     private Double toDouble(String value) throws SQLException {
         try {
-            return Double.valueOf(new BigDecimal(value).doubleValue());
+            return Double.parseDouble(value);
         }
         catch (NumberFormatException e) {
             throw new BQSQLException(e);
         }
     }
 
-
     /** Parse integral types */
     private Long toLong(String value) throws SQLException {
         try {
-            return Long.valueOf(new BigDecimal(value).longValue());
+            return Long.parseLong(value);
         }
         catch (NumberFormatException e) {
             throw new BQSQLException(e);

--- a/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/BQForwardOnlyResultSetFunctionTest.java
@@ -292,7 +292,7 @@ public class BQForwardOnlyResultSetFunctionTest {
         this.QueryLoad();
         try {
             Assert.assertTrue(resultForTest.next());
-            Assert.assertEquals(new Float(42),
+            Assert.assertEquals(42f,
                     resultForTest.getFloat(2));
         } catch (SQLException e) {
             this.logger.error("SQLexception" + e.toString());
@@ -486,7 +486,9 @@ public class BQForwardOnlyResultSetFunctionTest {
                 "DATETIME('2012-01-01 00:00:02'), " +
                 "TIMESTAMP('2012-01-01 00:00:03'), " +
                 "CAST('2312412432423423334.234234234' AS NUMERIC), " +
-                "CAST('2011-04-03' AS DATE)";
+                "CAST('2011-04-03' AS DATE), " +
+                "CAST('nan' AS FLOAT)"
+                ;
 
         this.NewConnection(true);
         java.sql.ResultSet result = null;
@@ -512,6 +514,8 @@ public class BQForwardOnlyResultSetFunctionTest {
         SimpleDateFormat dateDateFormat = new SimpleDateFormat("yyyy-MM-dd");
         Date parsedDateDate = new java.sql.Date(dateDateFormat.parse("2011-04-03").getTime());
         Assert.assertEquals(parsedDateDate, result.getObject(4));
+
+        Assert.assertEquals(Double.NaN, result.getObject(5));
     }
 
     @Test


### PR DESCRIPTION
Previously, the unnecessary parsing to BigDecimal would explode on NaN (and Inf, etc). Double.parseDouble has no problem with this.