### PR TITLE
Disable pretty printing by default

### DIFF
--- a/src/main/java/com/google/api/services/bigquery/MinifiedBigquery.java
+++ b/src/main/java/com/google/api/services/bigquery/MinifiedBigquery.java
@@ -1,0 +1,259 @@
+package com.google.api.services.bigquery;
+
+import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
+import com.google.api.client.http.AbstractInputStreamContent;
+import com.google.api.services.bigquery.model.Dataset;
+import com.google.api.services.bigquery.model.GetIamPolicyRequest;
+import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.Model;
+import com.google.api.services.bigquery.model.QueryRequest;
+import com.google.api.services.bigquery.model.Routine;
+import com.google.api.services.bigquery.model.SetIamPolicyRequest;
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableDataInsertAllRequest;
+import com.google.api.services.bigquery.model.TestIamPermissionsRequest;
+
+import java.io.IOException;
+
+/**
+ * A small proxy class with which every request is by default minified JSON.
+ * This is to help improve performance for BigQuery as for certain payloads the cost of whitespace
+ * can be quite taxing.
+ */
+public class MinifiedBigquery extends Bigquery{
+
+    /**
+     * By default we minify (non-pretty) the JSON.
+     * We leave it toggleable for debugging purposes.
+     */
+    private boolean pretty;
+    
+    /**
+     * The way in which we create our minified version.
+     * Create a normal builder but don't call build but pass it to this constructor.
+     * Defaults the pretty printing to false.
+     */
+    public MinifiedBigquery(Builder builder) {
+        this(builder, false);
+    }
+
+    public MinifiedBigquery(Builder builder, boolean pretty) {
+        super(builder);
+        this.pretty = pretty;
+    }
+    
+    @Override
+    protected void initialize(AbstractGoogleClientRequest<?> httpClientRequest) throws IOException {
+        super.initialize(httpClientRequest);
+    }
+
+    @Override
+    public Datasets datasets() {
+        return new Datasets() {
+            @Override
+            public Delete delete(String projectId, String datasetId) throws IOException {
+                return super.delete(projectId, datasetId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Get get(String projectId, String datasetId) throws IOException {
+                return super.get(projectId, datasetId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Insert insert(String projectId, Dataset content) throws IOException {
+                return super.insert(projectId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list(String projectId) throws IOException {
+                return super.list(projectId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Patch patch(String projectId, String datasetId, Dataset content) throws IOException {
+                return super.patch(projectId, datasetId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Update update(String projectId, String datasetId, Dataset content) throws IOException {
+                return super.update(projectId, datasetId, content).setPrettyPrint(pretty);
+            }
+        };
+    }
+
+    @Override
+    public Jobs jobs() {
+        return new Jobs() {
+            @Override
+            public Cancel cancel(String projectId, String jobId) throws IOException {
+                return super.cancel(projectId, jobId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Get get(String projectId, String jobId) throws IOException {
+                return super.get(projectId, jobId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public GetQueryResults getQueryResults(String projectId, String jobId) throws IOException {
+                return super.getQueryResults(projectId, jobId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Insert insert(String projectId, Job content) throws IOException {
+                return super.insert(projectId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Insert insert(String projectId, Job content, AbstractInputStreamContent mediaContent) throws IOException {
+                return super.insert(projectId, content, mediaContent).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list(String projectId) throws IOException {
+                return super.list(projectId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Query query(String projectId, QueryRequest content) throws IOException {
+                return super.query(projectId, content).setPrettyPrint(pretty);
+            }
+        };
+    }
+
+    @Override
+    public Models models() {
+        return new Models() {
+            @Override
+            public Delete delete(String projectId, String datasetId, String modelId) throws IOException {
+                return super.delete(projectId, datasetId, modelId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Get get(String projectId, String datasetId, String modelId) throws IOException {
+                return super.get(projectId, datasetId, modelId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list(String projectId, String datasetId) throws IOException {
+                return super.list(projectId, datasetId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Patch patch(String projectId, String datasetId, String modelId, Model content) throws IOException {
+                return super.patch(projectId, datasetId, modelId, content).setPrettyPrint(pretty);
+            }
+        };
+    }
+
+    @Override
+    public Projects projects() {
+        return new Projects() {
+            @Override
+            public GetServiceAccount getServiceAccount(String projectId) throws IOException {
+                return super.getServiceAccount(projectId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list() throws IOException {
+                return super.list().setPrettyPrint(pretty);
+            }
+        };
+    }
+
+    @Override
+    public Routines routines() {
+        return new Routines() {
+            @Override
+            public Delete delete(String projectId, String datasetId, String routineId) throws IOException {
+                return super.delete(projectId, datasetId, routineId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Get get(String projectId, String datasetId, String routineId) throws IOException {
+                return super.get(projectId, datasetId, routineId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Insert insert(String projectId, String datasetId, Routine content) throws IOException {
+                return super.insert(projectId, datasetId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list(String projectId, String datasetId) throws IOException {
+                return super.list(projectId, datasetId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Update update(String projectId, String datasetId, String routineId, Routine content) throws IOException {
+                return super.update(projectId, datasetId, routineId, content).setPrettyPrint(pretty);
+            }
+        };
+    }
+
+    @Override
+    public Tabledata tabledata() {
+        return new Tabledata() {
+            @Override
+            public InsertAll insertAll(String projectId, String datasetId, String tableId, TableDataInsertAllRequest content) throws IOException {
+                return super.insertAll(projectId, datasetId, tableId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list(String projectId, String datasetId, String tableId) throws IOException {
+                return super.list(projectId, datasetId, tableId).setPrettyPrint(pretty);
+            }
+        };
+    }
+
+    @Override
+    public Tables tables() {
+        return new Tables() {
+            @Override
+            public Delete delete(String projectId, String datasetId, String tableId) throws IOException {
+                return super.delete(projectId, datasetId, tableId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Get get(String projectId, String datasetId, String tableId) throws IOException {
+                return super.get(projectId, datasetId, tableId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public GetIamPolicy getIamPolicy(String resource, GetIamPolicyRequest content) throws IOException {
+                return super.getIamPolicy(resource, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Insert insert(String projectId, String datasetId, Table content) throws IOException {
+                return super.insert(projectId, datasetId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public List list(String projectId, String datasetId) throws IOException {
+                return super.list(projectId, datasetId).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Patch patch(String projectId, String datasetId, String tableId, Table content) throws IOException {
+                return super.patch(projectId, datasetId, tableId, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public SetIamPolicy setIamPolicy(String resource, SetIamPolicyRequest content) throws IOException {
+                return super.setIamPolicy(resource, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public TestIamPermissions testIamPermissions(String resource, TestIamPermissionsRequest content) throws IOException {
+                return super.testIamPermissions(resource, content).setPrettyPrint(pretty);
+            }
+
+            @Override
+            public Update update(String projectId, String datasetId, String tableId, Table content) throws IOException {
+                return super.update(projectId, datasetId, tableId, content).setPrettyPrint(pretty);
+            }
+        };
+    }
+}

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -40,6 +40,7 @@ import com.google.api.services.bigquery.Bigquery.Builder;
 import com.google.api.services.bigquery.BigqueryRequest;
 import com.google.api.services.bigquery.BigqueryRequestInitializer;
 import com.google.api.services.bigquery.BigqueryScopes;
+import com.google.api.services.bigquery.MinifiedBigquery;
 import com.google.api.services.iamcredentials.v1.IAMCredentials;
 import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenRequest;
 import com.google.api.services.iamcredentials.v1.model.GenerateAccessTokenResponse;
@@ -124,7 +125,7 @@ public class Oauth2Bigquery {
         }
         bqBuilder.setBigqueryRequestInitializer(requestInitializer);
 
-        Bigquery bigquery = bqBuilder.build();
+        Bigquery bigquery = new MinifiedBigquery(bqBuilder);
 
         return bigquery;
     }
@@ -234,7 +235,7 @@ public class Oauth2Bigquery {
             bqBuilder.setBigqueryRequestInitializer(requestInitializer);
         }
 
-        return bqBuilder.build();
+        return new MinifiedBigquery(bqBuilder);
     }
 
     /**

--- a/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
@@ -1,6 +1,5 @@
 package BQJDBC.QueryResultTest;
 
-import com.google.api.services.bigquery.Bigquery;
 import junit.framework.Assert;
 import net.starschema.clouddb.jdbc.Oauth2Bigquery;
 import net.starschema.clouddb.jdbc.BQConnection;
@@ -33,7 +32,7 @@ public class JdbcUrlTest {
         URL = getUrl("/installedaccount.properties", null) + "&useLegacySql=true";;
         this.bq = new BQConnection(URL, new Properties());
     }
-    
+
     @Test
     public void urlWithDefaultDatasetShouldWork() throws SQLException {
         Assert.assertEquals(properties.getProperty("dataset"), bq.getDataSet());

--- a/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/JdbcUrlTest.java
@@ -1,5 +1,6 @@
 package BQJDBC.QueryResultTest;
 
+import com.google.api.services.bigquery.Bigquery;
 import junit.framework.Assert;
 import net.starschema.clouddb.jdbc.Oauth2Bigquery;
 import net.starschema.clouddb.jdbc.BQConnection;
@@ -32,7 +33,7 @@ public class JdbcUrlTest {
         URL = getUrl("/installedaccount.properties", null) + "&useLegacySql=true";;
         this.bq = new BQConnection(URL, new Properties());
     }
-
+    
     @Test
     public void urlWithDefaultDatasetShouldWork() throws SQLException {
         Assert.assertEquals(properties.getProperty("dataset"), bq.getDataSet());

--- a/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
+++ b/src/test/java/BQJDBC/QueryResultTest/QueryResultTest.java
@@ -238,7 +238,7 @@ public class QueryResultTest {
             result = stmt.executeQuery(sql);
         } catch (SQLException e) {
             this.logger.debug("SQLexception" + e.toString());
-            Assert.assertTrue(e.toString().contains("Not found: Table measurement-lab:m_lab.2010_01"));
+                Assert.assertTrue(e.toString().contains("Not found: Table guid754187384106:m_lab.2010_01"));
         }
     }
 


### PR DESCRIPTION
According to feedback from the BigQuery team there is significant overhead in the whitespace processing for BigQuery pretty printed JSON.

They recommend disabling it and they call out bigquery.jobs.getQueryResults and bigquery.tabledata.list as the big winners.

It was kind of tedious to turn it off for every API call, so I introduce a new proxy _Bigquery_ class that sets it for every request type.