### PR TITLE
Add support for custom endpoint as a JDBC parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,24 @@ A fat (shaded) jar is also available:
 
 We require Java (JDK 8 through 15) and Apache Maven (3.2.5 or higher).
 
-```
+```bash
 $ git clone git://github.com/jonathanswenson/starschema-bigquery-jdbc.git
 $ cd starschema-bigquery-jdbc
 $ mvn clean install -DskipTests
+```
+
+### Local testing
+Testing locally requires access to secret credentials stored in
+[Google Secret Manager](https://console.cloud.google.com/security/secret-manager/secret/bqjdbc-resources-zip/versions?project=346285421363)
+for accessing Looker-owned BigQuery testing tables.
+Once granted access, download and extract the zip file:
+
+```bash
+# Assuming you've already authenticated with `gcloud auth login`:
+$ gcloud config set project secrets-305922
+$ cd src/test/resources
+$ gcloud secrets versions access latest --secret=bqjdbc-resources-zip --format='get(payload.data)' | tr '_-' '/+' | base64 -d > resources.zip
+$ unzip resources.zip
 ```
 
 ### Releases

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -81,6 +81,8 @@ public class BQSupportFuncts {
         dataset = dataset == null ? properties.getProperty("dataset") : dataset;
 
         String forreturn = "";
+        // Set to '?' for the first param and '&' for subsequent params.
+        String paramSep = "?";
 
         if (properties.getProperty("type").equals("installed")) {
             if (User != null && Password != null && projectId != null) {
@@ -95,6 +97,7 @@ public class BQSupportFuncts {
                         + URLEncoder.encode(projectId, "UTF-8")
                         + (dataset != null && full ? "/" + URLEncoder.encode(dataset, "UTF-8") : "")
                         + "?withServiceAccount=true";
+                paramSep = "&";
                 if (full) {
                     forreturn += "&user=" + URLEncoder.encode(User, "UTF-8") + "&password=" + URLEncoder.encode(Password, "UTF-8");
                     if (path != null) {
@@ -112,6 +115,7 @@ public class BQSupportFuncts {
                     + (dataset != null && full ? "/" + URLEncoder.encode(dataset, "UTF-8") : "");
                 if (full) {
                     forreturn += "?oAuthAccessToken=" + URLEncoder.encode(accessToken, "UTF-8");
+                    paramSep = "&";
                 }
             } else {
                 return null;
@@ -122,12 +126,14 @@ public class BQSupportFuncts {
 
         String useLegacySql = properties.getProperty("useLegacySql");
         if (useLegacySql != null) {
-            if (properties.getProperty("type").equals("service")) {
-                forreturn += "&useLegacySql=" + useLegacySql;
-            }
-            else {
-                forreturn += "?useLegacySql=" + useLegacySql;
-            }
+            forreturn += paramSep + "useLegacySql=" + useLegacySql;
+            paramSep = "&";
+        }
+
+        String rootUrl = properties.getProperty("rootUrl");
+        if (rootUrl != null) {
+            forreturn += paramSep + "rootUrl=" + URLEncoder.encode(rootUrl, "UTF-8");
+            paramSep = "&";
         }
 
         return forreturn;

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -65,7 +65,7 @@ import java.util.regex.Pattern;
 public class Oauth2Bigquery {
 
     /** Global instance of the HTTP transport. */
-    private static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
+    static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
 
     /** Global instance of the JSON factory. */
     private static final JsonFactory JSON_FACTORY = new JacksonFactory();
@@ -97,9 +97,11 @@ public class Oauth2Bigquery {
     public static Bigquery authorizeViaToken(String oauthToken,
                                              String userAgent,
                                              Integer connectTimeout,
-                                             Integer readTimeout) throws SQLException {
+                                             Integer readTimeout,
+                                             String rootUrl,
+                                             HttpTransport httpTransport) throws SQLException {
         GoogleCredential.Builder builder = new GoogleCredential.Builder()
-            .setTransport(HTTP_TRANSPORT)
+            .setTransport(httpTransport)
             .setJsonFactory(JSON_FACTORY);
         GoogleCredential credential = builder.build();
 
@@ -113,7 +115,7 @@ public class Oauth2Bigquery {
 
         logger.debug("Creating a new bigquery client.");
         Builder bqBuilder = new Builder(
-            HTTP_TRANSPORT,
+            httpTransport,
             JSON_FACTORY,
             httpRequestInitializer
         ).setApplicationName(applicationName);
@@ -124,6 +126,10 @@ public class Oauth2Bigquery {
             requestInitializer.setUserAgent(userAgent);
         }
         bqBuilder.setBigqueryRequestInitializer(requestInitializer);
+
+        if (rootUrl != null) {
+            bqBuilder.setRootUrl(rootUrl);
+        }
 
         Bigquery bigquery = new MinifiedBigquery(bqBuilder);
 
@@ -205,11 +211,15 @@ public class Oauth2Bigquery {
      * @throws GeneralSecurityException
      * @throws IOException
      */
-    public static Bigquery authorizeviaservice(String serviceaccountemail,
+    public static Bigquery authorizeViaService(String serviceaccountemail,
                                                String keypath,
                                                String password,
                                                String userAgent,
-                                               String jsonAuthContents, Integer readTimeout, Integer connectTimeout) throws GeneralSecurityException, IOException {
+                                               String jsonAuthContents,
+                                               Integer readTimeout,
+                                               Integer connectTimeout,
+                                               String rootUrl,
+                                               HttpTransport httpTransport) throws GeneralSecurityException, IOException {
         GoogleCredential credential = createServiceAccountCredential(serviceaccountemail, keypath, password, jsonAuthContents, false);
 
         logger.debug("Authorizied?");
@@ -223,7 +233,7 @@ public class Oauth2Bigquery {
         }
 
         Bigquery.Builder bqBuilder = new Builder(
-                HTTP_TRANSPORT,
+                httpTransport,
                 JSON_FACTORY,
                 httpRequestInitializer)
                 .setApplicationName(applicationName);
@@ -233,6 +243,10 @@ public class Oauth2Bigquery {
             requestInitializer.setUserAgent(userAgent);
 
             bqBuilder.setBigqueryRequestInitializer(requestInitializer);
+        }
+
+        if (rootUrl != null) {
+            bqBuilder.setRootUrl(rootUrl);
         }
 
         return new MinifiedBigquery(bqBuilder);

--- a/src/test/resources/vpcaccount.properties
+++ b/src/test/resources/vpcaccount.properties
@@ -1,0 +1,7 @@
+projectid=super-party-888
+type=service
+user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
+password=src/test/resources/bigquery_credentials.p12
+dataset=looker_test
+transformquery=true
+rootUrl=https://restricted.googleapis.com/


### PR DESCRIPTION
Enable using e.g. `rootUrl=https%3A%2F%2Fcustom.bq.com%2F` (URL-decoded: `https://custom.bq.com/`) to hit alternative endpoints to `https://bigquery.googleapis.com/`.

I've added a new properties file for the test and just checked it in since it does not contains any secrets per se (though it references `bigquery_credentials.p12` even though it doesn't make any real requests). I can also just add it to the zip archive that I uploaded to Secret Manager for easier distribution of the files. I also included instructions in the README for accessing those secrets, which are accessible to everyone in the `cloud-looker-model-dev@google.com` group and could potentially be made available to others if we want to.