### PR TITLE
Add support for sending per-statement labels

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -212,7 +212,7 @@ public class BQConnection implements Connection {
         String userAgent = caseInsensitiveProps.getProperty("useragent");
 
         // extract any labels
-        this.labels = tryParseLabels(caseInsensitiveLoginProps.getProperty("labels"));
+        this.labels = tryParseLabels(caseInsensitiveProps.getProperty("labels"));
         // extract custom endpoint for connections through restricted VPC
         String rootUrl = caseInsensitiveProps.getProperty("rooturl");
       


### PR DESCRIPTION
The driver will now accept per-statement labels in addition to the per-connection labels. It checks to make sure it doesn't send more than the [max of 64 labels per query](https://cloud.google.com/bigquery/docs/labels-intro#requirements), but doesn't check anything else about label validity. I have an accompanying PR for Looker to make use of this. This introduces an auxiliary API that is not typical of JDBC drivers and would not normally be used by "typical" users of this driver. As such, it is end-to-end tested in helltool, but not here.