### PR TITLE
Record total_bytes_processed and cache_hit on results sets

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQScrollableResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQScrollableResultSet.java
@@ -62,6 +62,12 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
      */
     private BQStatement Statementreference = null;
 
+    /** The total number of bytes processed while creating this ResultSet */
+    private final long totalBytesProcessed;
+
+    /** Whether the ResultSet came from BigQuery's cache */
+    private final boolean cacheHit;
+
     private TableSchema schema;
 
     /**
@@ -72,7 +78,12 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
      */
     public BQScrollableResultSet(GetQueryResultsResponse bigQueryGetQueryResultResponse,
                                  BQStatementRoot bqStatementRoot) {
-        this(bigQueryGetQueryResultResponse.getRows(), bqStatementRoot, bigQueryGetQueryResultResponse.getSchema());
+        this(
+            bigQueryGetQueryResultResponse.getRows(),
+            bqStatementRoot,
+            bigQueryGetQueryResultResponse.getSchema(),
+            bigQueryGetQueryResultResponse.getTotalBytesProcessed(),
+            bigQueryGetQueryResultResponse.getCacheHit());
 
         BigInteger maxrow;
         try {
@@ -82,7 +93,7 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
         } // Should not happen.
     }
 
-    public BQScrollableResultSet(List<TableRow> rows, BQStatementRoot bqStatementRoot, TableSchema schema) {
+    public BQScrollableResultSet(List<TableRow> rows, BQStatementRoot bqStatementRoot, TableSchema schema, long totalBytesProcessed, boolean cacheHit) {
         logger.debug("Created Scrollable resultset TYPE_SCROLL_INSENSITIVE");
         try {
             maxFieldSize = bqStatementRoot.getMaxFieldSize();
@@ -99,6 +110,8 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
         }
 
         this.schema = schema;
+        this.totalBytesProcessed = totalBytesProcessed;
+        this.cacheHit = cacheHit;
     }
 
     /** {@inheritDoc} */
@@ -241,5 +254,13 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
                 return result;
             }
         }
+    }
+
+    public long getTotalBytesProcessed() {
+        return totalBytesProcessed;
+    }
+
+    public boolean getCacheHit() {
+        return cacheHit;
     }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -167,11 +167,11 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                     return new BQForwardOnlyResultSet(
                             this.connection.getBigquery(),
                             projectId,
-                            referencedJob, this, qr.getRows(), fetchedAll, qr.getSchema());
+                            referencedJob, this, qr.getRows(), fetchedAll, qr.getSchema(), qr.getTotalBytesProcessed(), qr.getCacheHit());
                 } else if (fetchedAll) {
                     // We can only return scrollable result sets here if we have all the rows: otherwise we'll
                     // have to go get more below
-                    return new BQScrollableResultSet(qr.getRows(), this, qr.getSchema());
+                    return new BQScrollableResultSet(qr.getRows(), this, qr.getSchema(), qr.getTotalBytesProcessed(), qr.getCacheHit());
                 }
                 jobAlreadyCompleted = true;
             }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -326,7 +326,7 @@ public abstract class BQStatementRoot {
             );
             if (qr.getJobComplete()) {
                 if (qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()))) {
-                    return new BQScrollableResultSet(qr.getRows(), this, qr.getSchema());
+                    return new BQScrollableResultSet(qr.getRows(), this, qr.getSchema(), qr.getTotalBytesProcessed(), qr.getCacheHit());
                 }
                 jobAlreadyCompleted = true;
             }

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * This Junit test tests functions in BQResultset
+ * This Junit test tests functions in BQForwardOnlyResultSet
  *
  * @author Horváth Attila
  * @author Gunics Balazs
@@ -579,6 +579,14 @@ public class BQForwardOnlyResultSetFunctionTest {
 
         // also check that explicit casts to TIME work as expected
         Assert.assertEquals(result.getTime(2).toString(), "00:00:02");
+    }
+
+    @Test
+    public void TestResultSetTotalBytesProcessedCacheHit() {
+        QueryLoad();
+        Assert.assertTrue(resultForTest instanceof BQForwardOnlyResultSet);
+        BQForwardOnlyResultSet results = (BQForwardOnlyResultSet)resultForTest;
+        Assert.assertEquals(results.getTotalBytesProcessed() == 0, results.getCacheHit());
     }
 
 }

--- a/src/test/java/net/starschema/clouddb/jdbc/BQScrollableResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQScrollableResultSetFunctionTest.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This Junit test tests functions in BQResultset
+ * This Junit test tests functions in BQScrollableResultSet
  *
  * @author Horváth Attila
  * @author Gunics Balazs
@@ -716,6 +716,13 @@ public class BQScrollableResultSetFunctionTest {
                 Assert.fail("SQLException" + e.toString());
             }
         }
+    }
+
+    @Test
+    public void TestResultSetTotalBytesProcessedCacheHit() {
+        Assert.assertTrue(Result instanceof BQScrollableResultSet);
+        BQScrollableResultSet results = (BQScrollableResultSet)Result;
+        Assert.assertEquals(results.getTotalBytesProcessed() == 0, results.getCacheHit());
     }
 
 }

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -229,7 +229,9 @@ public class JdbcUrlTest {
         String mockResponse =
             "{ \"jobComplete\": true, "
             + "\"totalRows\": \"0\", "
-            + "\"rows\": [] }";
+            + "\"rows\": [], "
+            + "\"totalBytesProcessed\": \"0\", "
+            + "\"cacheHit\": false }";
         MockHttpTransport mockTransport =
             new MockHttpTransport.Builder()
                 .setLowLevelHttpResponse(

--- a/src/test/java/net/starschema/clouddb/jdbc/QueryResultTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/QueryResultTest.java
@@ -185,6 +185,22 @@ public class QueryResultTest {
             this.logger.error("SQLexception" + e.toString());
             Assert.fail(e.toString());
         }
+
+        Assert.assertTrue(Result instanceof BQForwardOnlyResultSet || Result instanceof BQScrollableResultSet);
+
+        long totalBytesProcessed;
+        boolean cacheHit;
+        if (Result instanceof BQForwardOnlyResultSet) {
+            BQForwardOnlyResultSet bqForwardOnlyResultSet = (BQForwardOnlyResultSet)Result;
+            totalBytesProcessed = bqForwardOnlyResultSet.getTotalBytesProcessed();
+            cacheHit = bqForwardOnlyResultSet.getCacheHit();
+        } else {
+            BQScrollableResultSet bqScrollableResultSet = (BQScrollableResultSet)Result;
+            totalBytesProcessed = bqScrollableResultSet.getTotalBytesProcessed();
+            cacheHit = bqScrollableResultSet.getCacheHit();
+        }
+
+        Assert.assertEquals(cacheHit, totalBytesProcessed == 0);
     }
 
     @Test


### PR DESCRIPTION
I'm unsure exactly how to assert in the test since these values may or may not be subject to change. Documentation is underspecified. This seems to work.