### PR TITLE
Add support for 'queryCache' parameter

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -60,7 +60,6 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     private Job job;
     private AtomicReference<Thread> runningSyncThread = new AtomicReference<>();
     private AtomicReference<QueryResponse> syncResponseFromCurrentQuery = new AtomicReference<>();
-    private AtomicReference<JobReference> mostRecentJobReference = new AtomicReference<>();
     // Labels to be sent with the request
     // (in addition to the ones specified in the connection string).
     private ImmutableMap<String, String> statementLabels = ImmutableMap.of();
@@ -310,7 +309,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                         this.getAllLabels(),
                         this.connection.getUseQueryCache());
                 syncResponseFromCurrentQuery.set(resp);
-                mostRecentJobReference.set(resp.getJobReference());
+                this.mostRecentJobReference.set(resp.getJobReference());
             } catch (Exception e) {
                 diedWith.set(e);
             }
@@ -395,7 +394,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
      * Requires supplying an explicit connection.
      */
     public Map<String, String> getLabelsFromMostRecentQuery(BQConnection connection) throws SQLException {
-        JobReference jobReference = mostRecentJobReference.get();
+        JobReference jobReference = this.mostRecentJobReference.get();
         if (jobReference != null) {
             try {
                 return connection.getBigquery()

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -30,6 +30,7 @@ package net.starschema.clouddb.jdbc;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.QueryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * This class partially implements java.sql.Statement, and
@@ -92,6 +94,8 @@ public abstract class BQStatementRoot {
      * to be used with setMaxFieldSize
      */
     private int maxFieldSize = 0;
+
+    protected AtomicReference<JobReference> mostRecentJobReference = new AtomicReference<>();
 
     /**
      * <p>
@@ -272,6 +276,7 @@ public abstract class BQStatementRoot {
                     this.getAllLabels(),
                     this.connection.getUseQueryCache()
             );
+            this.mostRecentJobReference.set(qr.getJobReference());
 
             if (defaultValueIfNull(qr.getJobComplete(), false)) {
                 // I hope they don't insert more than 2^32-1 :)
@@ -331,6 +336,8 @@ public abstract class BQStatementRoot {
                     this.getAllLabels(),
                     this.connection.getUseQueryCache()
             );
+            this.mostRecentJobReference.set(qr.getJobReference());
+
             if (defaultValueIfNull(qr.getJobComplete(), false)) {
                 List<TableRow> rows = defaultValueIfNull(qr.getRows(), new ArrayList<TableRow>());
                 if (BigInteger.valueOf(rows.size()).equals(qr.getTotalRows())) {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -39,6 +39,7 @@ import java.math.BigInteger;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This class partially implements java.sql.Statement, and
@@ -268,7 +269,8 @@ public abstract class BQStatementRoot {
                     this.connection.getMaxBillingBytes(),
                     (long) querytimeout * 1000,
                     (long) getMaxRows(),
-                    this.connection.getLabels()
+                    this.getAllLabels(),
+                    this.connection.getUseQueryCache()
             );
 
             if (defaultValueIfNull(qr.getJobComplete(), false)) {
@@ -326,7 +328,8 @@ public abstract class BQStatementRoot {
                     billingBytes,
                     (long) querytimeout * 1000,
                     (long) getMaxRows(),
-                    this.connection.getLabels()
+                    this.getAllLabels(),
+                    this.connection.getUseQueryCache()
             );
             if (defaultValueIfNull(qr.getJobComplete(), false)) {
                 List<TableRow> rows = defaultValueIfNull(qr.getRows(), new ArrayList<TableRow>());
@@ -380,6 +383,10 @@ public abstract class BQStatementRoot {
         // support that :(
         throw new BQSQLException(
                 "Query run took more than the specified timeout");
+    }
+
+    protected Map<String, String> getAllLabels() {
+        return this.connection.getLabels();
     }
 
     private static <T> T defaultValueIfNull(T value, T defaultValue) {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -138,6 +138,12 @@ public class BQSupportFuncts {
             paramSep = "&";
         }
 
+        String useQueryCache = properties.getProperty("queryCache");
+        if (useQueryCache != null) {
+            forreturn += paramSep + "queryCache=" + URLEncoder.encode(useQueryCache, "UTF-8");
+            paramSep = "&";
+        }
+
         return forreturn;
     }
 
@@ -578,10 +584,11 @@ public class BQSupportFuncts {
     static QueryResponse runSyncQuery(Bigquery bigquery, String projectId,
                                       String querySql, String dataSet, Boolean useLegacySql,
                                       Long maxBillingBytes, Long queryTimeoutMs, Long maxResults,
-                                      Map<String, String> labels
+                                      Map<String, String> labels, boolean useQueryCache
     ) throws IOException {
         QueryRequest qr = new QueryRequest()
                 .setLabels(labels)
+                .setUseQueryCache(useQueryCache)
                 .setTimeoutMs(queryTimeoutMs)
                 .setQuery(querySql)
                 .setUseLegacySql(useLegacySql)


### PR DESCRIPTION
This adds a new query parameter `queryCache` that can be used to disable BigQuery's cache. By default, the cache is enabled, but if the user sets this param to anything other than `true` (case-insensitive), it will be disabled.

Also does a bit of refactoring for the labels logic so that per-statement labels are no longer ignored when the query execution logic goes through `BQStatementRoot` rather than `BQStatement`. I'm not sure this would ever be an issue for Looker, but figured it's worth patching and adding a unit test.