### PR TITLE
Upgrade commons-io from 1.3.2 to 2.11.0 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>
@@ -180,6 +180,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.2.0</version>
         <configuration>
           <!-- this project has a lot of incorrect javadoc. punting on it for now fixing it. -->
           <doclint>none</doclint>


### PR DESCRIPTION
to address https://snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109

this is a significant version jump, but both:
+ 1.3.2 -> 1.4 claims to be binary, source, and semantic compatibile (https://commons.apache.org/proper/commons-io/upgradeto1_4.html)
+ 1.4 -> 2.11.0 claims to be binary, source, and semantic compatibile (https://commons.apache.org/proper/commons-io/upgradeto2_0.html)

In both cases they note only small semantic changes due to bug fixes and changes to the JVM version compatibility,
effectively deprecating support for JDK 1.3 and 1.4. Seeing as the driver only claims to support JDK 8+ (to 15)
this shouldn't cause any breaking changes to the driver.

Additionally this fixes a small warning thrown by maven about not specifying a version for the mvn-javadoc-plugin.