### PR TITLE
Add `timeoutMs` URL param

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -71,7 +71,7 @@ public class BQConnection implements Connection {
 
     private Long maxBillingBytes;
 
-    private Integer jobTimeoutMs;
+    private Integer timeoutMs;
 
     private final Map<String, String> labels;
 
@@ -173,8 +173,8 @@ public class BQConnection implements Connection {
 
         String jsonAuthContents = caseInsensitiveProps.getProperty("jsonauthcontents");
 
-        // extract jobTimeoutMs property
-        this.jobTimeoutMs = parseIntQueryParam("jobTimeoutMs", caseInsensitiveProps.getProperty("jobtimeoutms"));
+        // extract timeoutMs property
+        this.timeoutMs = parseIntQueryParam("timeoutMs", caseInsensitiveProps.getProperty("timeoutms"));
 
         // extract readTimeout property
         Integer readTimeout = parseIntQueryParam("readTimeout", caseInsensitiveProps.getProperty("readtimeout"));
@@ -1102,7 +1102,7 @@ public class BQConnection implements Connection {
         return maxBillingBytes;
     }
 
-    public Integer getJobTimeoutMs() {
-        return jobTimeoutMs;
+    public Integer getTimeoutMs() {
+        return timeoutMs;
     }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -266,7 +266,7 @@ public class BQConnection implements Connection {
                     throw new BQSQLException(param + " must be positive.");
                 }
             } catch (NumberFormatException e) {
-                throw new BQSQLException("Bad number for " + param, e);
+                throw new BQSQLException("could not parse " + param + " parameter.", e);
             }
         }
         return val;

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -71,6 +71,8 @@ public class BQConnection implements Connection {
 
     private Long maxBillingBytes;
 
+    private Integer jobTimeoutMs;
+
     private final Map<String, String> labels;
 
     private final boolean useQueryCache;
@@ -171,31 +173,14 @@ public class BQConnection implements Connection {
 
         String jsonAuthContents = caseInsensitiveProps.getProperty("jsonauthcontents");
 
-        String readTimeoutString = caseInsensitiveProps.getProperty("readtimeout");
-        Integer readTimeout = null;
-        if (readTimeoutString != null) {
-            try {
-                readTimeout = Integer.parseInt(readTimeoutString);
-                if (readTimeout < 0) {
-                    throw new BQSQLException("readTimeout must be positive.");
-                }
-            } catch (NumberFormatException e) {
-                throw new BQSQLException("could not parse readTimeout parameter.", e);
-            }
-        }
+        // extract jobTimeoutMs property
+        this.jobTimeoutMs = parseIntQueryParam("jobTimeoutMs", caseInsensitiveProps.getProperty("jobtimeoutms"));
 
-        String connectTimeoutString = caseInsensitiveProps.getProperty("connecttimeout");
-        Integer connectTimeout = null;
-        if (connectTimeoutString != null) {
-            try {
-                connectTimeout = Integer.parseInt(connectTimeoutString);
-                if (connectTimeout < 0) {
-                    throw new BQSQLException("connectTimeout must be positive.");
-                }
-            } catch (NumberFormatException e) {
-                throw new BQSQLException("could not parse connectTimeout parameter.", e);
-            }
-        }
+        // extract readTimeout property
+        Integer readTimeout = parseIntQueryParam("readTimeout", caseInsensitiveProps.getProperty("readtimeout"));
+
+        // extract connectTimeout property
+        Integer connectTimeout = parseIntQueryParam("connectTimeout", caseInsensitiveProps.getProperty("connecttimeout"));
 
         String maxBillingBytesParam = caseInsensitiveProps.getProperty("maxbillingbytes");
         if (maxBillingBytesParam != null) {
@@ -266,6 +251,25 @@ public class BQConnection implements Connection {
      */
     private static boolean parseBooleanQueryParam(@Nullable String paramValue, boolean defaultValue) {
         return paramValue == null ? defaultValue : Boolean.parseBoolean(paramValue);
+    }
+
+    /**
+     * Return null if {@code paramValue} is null.
+     * Otherwise, return an Integer iff {@code paramValue} can be parsed as a positive int.
+     */
+    private static Integer parseIntQueryParam(String param, @Nullable String paramValue) throws BQSQLException {
+        Integer val = null;
+        if (paramValue != null) {
+            try {
+                val = Integer.parseInt(paramValue);
+                if (val < 0) {
+                    throw new BQSQLException(param + " must be positive.");
+                }
+            } catch (NumberFormatException e) {
+                throw new BQSQLException("Bad number for " + param, e);
+            }
+        }
+        return val;
     }
 
     /**
@@ -1096,5 +1100,9 @@ public class BQConnection implements Connection {
 
     public Long getMaxBillingBytes() {
         return maxBillingBytes;
+    }
+
+    public Integer getJobTimeoutMs() {
+        return jobTimeoutMs;
     }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -118,6 +118,14 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     }
 
     @Override
+    public int getQueryTimeout() {
+        if (this.connection.getJobTimeoutMs() != null) {
+            return this.connection.getJobTimeoutMs().intValue();
+        }
+        return this.querytimeout * 1000;
+    }
+
+    @Override
     protected Map<String, String> getAllLabels() {
         return
             ImmutableMap.<String, String>builder()
@@ -262,9 +270,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                 // application bandwidth.
                 Thread.sleep(500);
                 this.logger.debug("slept for 500" + "ms, querytimeout is: "
-                        + this.querytimeout + "s");
+                        + getQueryTimeout() + "ms");
             }
-            while (System.currentTimeMillis() - this.starttime <= (long) this.querytimeout * 1000);
+            while (System.currentTimeMillis() - this.starttime <= (long) getQueryTimeout());
             // it runs for a minimum of 1 time
         } catch (IOException e) {
             throw new BQSQLException(

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -120,7 +120,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     @Override
     public int getQueryTimeout() {
         if (this.connection.getTimeoutMs() != null) {
-            return this.connection.getTimeoutMs().intValue();
+            return this.connection.getTimeoutMs();
         }
         return this.querytimeout * 1000;
     }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -119,8 +119,8 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
 
     @Override
     public int getQueryTimeout() {
-        if (this.connection.getJobTimeoutMs() != null) {
-            return this.connection.getJobTimeoutMs().intValue();
+        if (this.connection.getTimeoutMs() != null) {
+            return this.connection.getTimeoutMs().intValue();
         }
         return this.querytimeout * 1000;
     }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -144,6 +144,12 @@ public class BQSupportFuncts {
             paramSep = "&";
         }
 
+        String timeoutMs = properties.getProperty("timeoutMs");
+        if (timeoutMs != null) {
+            forreturn += paramSep + "timeoutMs=" + URLEncoder.encode(timeoutMs, "UTF-8");
+            paramSep = "&";
+        }
+
         return forreturn;
     }
 
@@ -175,7 +181,7 @@ public class BQSupportFuncts {
     /**
      * Return a list of Projects which contains the String catalogname
      *
-     * @param projectId The String which the id of the result Projects must contain
+     * @param projectIdFilter The String which the id of the result Projects must contain
      * @param Connection  A valid BQConnection instance
      * @return a list of Projects which contains the String catalogname
      * @throws IOException <p>

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -253,7 +253,7 @@ public class JdbcUrlTest {
         try {
             new BQConnection(URL + "&timeoutMs=-1", new Properties());
         } catch (BQSQLException e) {
-            Assert.assertEquals(e.getMessage().contains("jobTimeoutMs must be positive"), true);
+            Assert.assertEquals(e.getMessage().contains("timeoutMs must be positive"), true);
         }
         try {
             new BQConnection(URL + "&timeoutMs=NotANumber", new Properties());

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -249,26 +249,26 @@ public class JdbcUrlTest {
     }
 
     @Test
-    public void jobTimeoutMsRejectsBadValues() throws Exception {
+    public void timeoutMsRejectsBadValues() throws Exception {
         try {
-            new BQConnection(URL + "&jobTimeoutMs=-1", new Properties());
+            new BQConnection(URL + "&timeoutMs=-1", new Properties());
         } catch (BQSQLException e) {
             Assert.assertEquals(e.getMessage().contains("jobTimeoutMs must be positive"), true);
         }
         try {
-            new BQConnection(URL + "&jobTimeoutMs=NotANumber", new Properties());
+            new BQConnection(URL + "&timeoutMs=NotANumber", new Properties());
         } catch (BQSQLException e) {
-            Assert.assertEquals(e.getMessage().contains("Bad number for jobTimeoutMs"), true);
+            Assert.assertEquals(e.getMessage().contains("Bad number for timeoutMs"), true);
         }
     }
 
     @Test
-    public void jobTimeoutMsWorks() throws Exception {
+    public void timeoutMsWorks() throws Exception {
         // should immediately kill the job
-        this.URL += "&jobTimeoutMs=1";
+        this.URL += "&timeoutMs=1";
         this.bq = new BQConnection(URL, new Properties());
         // ensure that the url string was parsed properly
-        Assert.assertEquals(this.bq.getJobTimeoutMs(), Integer.valueOf(1));
+        Assert.assertEquals(this.bq.getTimeoutMs(), Integer.valueOf(1));
         // this query takes about 50 second to complete normally
         String sqlStmt = "SELECT * from publicdata:samples.wikipedia";
         BQStatement stmt = new BQStatement(this.properties.getProperty("projectid"), this.bq);

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -253,12 +253,12 @@ public class JdbcUrlTest {
         try {
             new BQConnection(URL + "&timeoutMs=-1", new Properties());
         } catch (BQSQLException e) {
-            Assert.assertEquals(e.getMessage().contains("timeoutMs must be positive"), true);
+            Assert.assertEquals(e.getMessage().contains("timeoutMs must be positive."), true);
         }
         try {
             new BQConnection(URL + "&timeoutMs=NotANumber", new Properties());
         } catch (BQSQLException e) {
-            Assert.assertEquals(e.getMessage().contains("Bad number for timeoutMs"), true);
+            Assert.assertEquals(e.getMessage().contains("could not parse timeoutMs parameter."), true);
         }
     }
 

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -249,6 +249,39 @@ public class JdbcUrlTest {
     }
 
     @Test
+    public void jobTimeoutMsRejectsBadValues() throws Exception {
+        try {
+            new BQConnection(URL + "&jobTimeoutMs=-1", new Properties());
+        } catch (BQSQLException e) {
+            Assert.assertEquals(e.getMessage().contains("jobTimeoutMs must be positive"), true);
+        }
+        try {
+            new BQConnection(URL + "&jobTimeoutMs=NotANumber", new Properties());
+        } catch (BQSQLException e) {
+            Assert.assertEquals(e.getMessage().contains("Bad number for jobTimeoutMs"), true);
+        }
+    }
+
+    @Test
+    public void jobTimeoutMsWorks() throws Exception {
+        // should immediately kill the job
+        this.URL += "&jobTimeoutMs=1";
+        this.bq = new BQConnection(URL, new Properties());
+        // ensure that the url string was parsed properly
+        Assert.assertEquals(this.bq.getJobTimeoutMs(), Integer.valueOf(1));
+        // this query takes about 50 second to complete normally
+        String sqlStmt = "SELECT * from publicdata:samples.wikipedia";
+        BQStatement stmt = new BQStatement(this.properties.getProperty("projectid"), this.bq);
+        try {
+            stmt.executeQuery(sqlStmt);
+            Assert.fail("Query job should have timed out");
+        } catch (BQSQLException e) {
+            Assert.assertEquals(
+                e.getMessage().contains("Query run took more than the specified timeout"), true);
+        }
+    }
+
+    @Test
     public void queryCacheIsOnByDefault() throws Exception {
         // Sanity check to make sure the queryCache param is not set.
         Assert.assertFalse(this.URL.toLowerCase().contains("querycache"));

--- a/src/test/resources/sampleaccount.properties
+++ b/src/test/resources/sampleaccount.properties
@@ -2,3 +2,4 @@ projectid=super-party-888
 type=service
 user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
 password=src/test/resources/credentials_go_here.p12
+transformquery=true

--- a/src/test/resources/vpcaccount.properties
+++ b/src/test/resources/vpcaccount.properties
@@ -1,6 +1,7 @@
-projectid=super-party-888
+projectid=disco-parsec-659
 type=service
 user=697117590302-76cr6q3217nck6gks0kf4r151j4d9f8e@developer.gserviceaccount.com
-password=src/test/resources/bigquery_credentials.p12
 dataset=looker_test
+password=src/test/resources/bigquery_credentials.p12
 transformquery=true
+rootUrl=https://restricted.googleapis.com


### PR DESCRIPTION
Addresses FR raised [here](https://yaqs.corp.google.com/eng/q/4918674062948958208?team_name=2398870489016565760) by adding support for a `timeoutMs` param which overrides the default query timeout of `Integer.MAX_VALUE / 1000 - 1` 

The FR mentions the [`jobTimeoutMs` param](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration) but the driver only creates a `JobConfiguration` for prepared statements which (from my understanding) aren't used in Looker. So, I figured `timeoutMs` would get close enough.

Happy to change anything or drop it altogether -- seemed like an easy add 👍 