### PR TITLE
Add `timeoutMs` URL param

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -118,6 +118,14 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
     }
 
     @Override
+    public int getQueryTimeout() {
+        if (this.connection.getTimeoutMs() != null) {
+            return this.connection.getTimeoutMs();
+        }
+        return this.querytimeout * 1000;
+    }
+
+    @Override
     protected Map<String, String> getAllLabels() {
         return
             ImmutableMap.<String, String>builder()
@@ -262,9 +270,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                 // application bandwidth.
                 Thread.sleep(500);
                 this.logger.debug("slept for 500" + "ms, querytimeout is: "
-                        + this.querytimeout + "s");
+                        + getQueryTimeout() + "ms");
             }
-            while (System.currentTimeMillis() - this.starttime <= (long) this.querytimeout * 1000);
+            while (System.currentTimeMillis() - this.starttime <= (long) getQueryTimeout());
             // it runs for a minimum of 1 time
         } catch (IOException e) {
             throw new BQSQLException(

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -144,6 +144,12 @@ public class BQSupportFuncts {
             paramSep = "&";
         }
 
+        String timeoutMs = properties.getProperty("timeoutMs");
+        if (timeoutMs != null) {
+            forreturn += paramSep + "timeoutMs=" + URLEncoder.encode(timeoutMs, "UTF-8");
+            paramSep = "&";
+        }
+
         return forreturn;
     }
 
@@ -175,7 +181,7 @@ public class BQSupportFuncts {
     /**
      * Return a list of Projects which contains the String catalogname
      *
-     * @param projectId The String which the id of the result Projects must contain
+     * @param projectIdFilter The String which the id of the result Projects must contain
      * @param Connection  A valid BQConnection instance
      * @return a list of Projects which contains the String catalogname
      * @throws IOException <p>


### PR DESCRIPTION
Addresses FR raised [here](https://yaqs.corp.google.com/eng/q/4918674062948958208?team_name=2398870489016565760) by adding support for a `timeoutMs` param which overrides the default query timeout of `Integer.MAX_VALUE / 1000 - 1` 

The FR mentions the [`jobTimeoutMs` param](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfiguration) but the driver only creates a `JobConfiguration` for prepared statements which (from my understanding) aren't used in Looker. So, I figured `timeoutMs` would get close enough.

Happy to change anything or drop it altogether -- seemed like an easy add 👍 

Clone of closed PR: https://github.com/jonathanswenson/bqjdbc/pull/107