### PR TITLE
Allow totalBytesProcessed and cacheHit to be null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
        to a groupId that we have ownership over -->
   <groupId>com.github.jonathanswenson</groupId>
   <artifactId>bqjdbc</artifactId>
-  <version>2.3.11-SNAPSHOT</version>
+  <version>2.3.11</version>
   <name>Big Query over JDBC</name>
   <description>A simple JDBC driver, to reach Google's BigQuery</description>
   <properties>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQScrollableResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQScrollableResultSet.java
@@ -32,6 +32,7 @@ import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.ResultSetMetaData;
@@ -63,10 +64,10 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
     private BQStatement Statementreference = null;
 
     /** The total number of bytes processed while creating this ResultSet */
-    private final long totalBytesProcessed;
+    private final @Nullable Long totalBytesProcessed;
 
     /** Whether the ResultSet came from BigQuery's cache */
-    private final boolean cacheHit;
+    private final @Nullable Boolean cacheHit;
 
     private TableSchema schema;
 
@@ -93,7 +94,7 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
         } // Should not happen.
     }
 
-    public BQScrollableResultSet(List<TableRow> rows, BQStatementRoot bqStatementRoot, TableSchema schema, long totalBytesProcessed, boolean cacheHit) {
+    public BQScrollableResultSet(List<TableRow> rows, BQStatementRoot bqStatementRoot, TableSchema schema, @Nullable Long totalBytesProcessed, @Nullable Boolean cacheHit) {
         logger.debug("Created Scrollable resultset TYPE_SCROLL_INSENSITIVE");
         try {
             maxFieldSize = bqStatementRoot.getMaxFieldSize();
@@ -256,11 +257,11 @@ public class BQScrollableResultSet extends ScrollableResultset<Object> implement
         }
     }
 
-    public long getTotalBytesProcessed() {
+    public @Nullable Long getTotalBytesProcessed() {
         return totalBytesProcessed;
     }
 
-    public boolean getCacheHit() {
+    public @Nullable Boolean getCacheHit() {
         return cacheHit;
     }
 }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -191,15 +191,14 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                             (qr.getRows() != null && qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()))));
             // Don't look up the job if we have nothing else we need to do
             if (!(fetchedAll || this.connection.isClosed())) {
-                if (qr.getJobReference() == null) {
-                    throw new BQSQLException("Got BQ response with no job reference: " + qr.toString());
+                if (qr.getJobReference() != null) {
+                    referencedJob =
+                        this.connection.getBigquery()
+                            .jobs()
+                            .get(projectId, qr.getJobReference().getJobId())
+                            .setLocation(qr.getJobReference().getLocation())
+                            .execute();
                 }
-                referencedJob =
-                    this.connection.getBigquery()
-                        .jobs()
-                        .get(projectId, qr.getJobReference().getJobId())
-                        .setLocation(qr.getJobReference().getLocation())
-                        .execute();
             }
             if (jobComplete) {
                 if (resultSetType != ResultSet.TYPE_SCROLL_INSENSITIVE) {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -179,7 +179,7 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
         }
 
         this.starttime = System.currentTimeMillis();
-        Job referencedJob;
+        Job referencedJob = null;
         int retries = 0;
         boolean jobAlreadyCompleted = false;
 
@@ -190,33 +190,31 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                     (qr.getTotalRows().equals(BigInteger.ZERO) ||
                             (qr.getRows() != null && qr.getTotalRows().equals(BigInteger.valueOf(qr.getRows().size()))));
             // Don't look up the job if we have nothing else we need to do
-            referencedJob = fetchedAll || this.connection.isClosed() ?
-                    null :
-                    qr.getJobReference() == null ?
-                            null :
-                            this.connection.getBigquery()
-                                    .jobs()
-                                    .get(projectId, qr.getJobReference().getJobId())
-                                    .setLocation(qr.getJobReference().getLocation())
-                                    .execute();
+            if (!(fetchedAll || this.connection.isClosed())) {
+                if (qr.getJobReference() == null) {
+                    throw new BQSQLException("Got BQ response with no job reference: " + qr.toString());
+                }
+                referencedJob =
+                    this.connection.getBigquery()
+                        .jobs()
+                        .get(projectId, qr.getJobReference().getJobId())
+                        .setLocation(qr.getJobReference().getLocation())
+                        .execute();
+            }
             if (jobComplete) {
                 if (resultSetType != ResultSet.TYPE_SCROLL_INSENSITIVE) {
-                    Boolean cacheHit = defaultValueIfNull(qr.getCacheHit(), false);
-                    Long totalBytesProcessed = defaultValueIfNull(qr.getTotalBytesProcessed(), 0L);
                     List<TableRow> rows = defaultValueIfNull(qr.getRows(), new ArrayList<TableRow>());
                     TableSchema schema = defaultValueIfNull(qr.getSchema(), new TableSchema());
 
                     return new BQForwardOnlyResultSet(
                             this.connection.getBigquery(),
                             projectId,
-                            referencedJob, this, rows, fetchedAll, schema, totalBytesProcessed, cacheHit);
+                            referencedJob, this, rows, fetchedAll, schema, qr.getTotalBytesProcessed(), qr.getCacheHit());
                 } else if (fetchedAll) {
                     // We can only return scrollable result sets here if we have all the rows: otherwise we'll
                     // have to go get more below
-                    Boolean cacheHit = defaultValueIfNull(qr.getCacheHit(), false);
-                    Long totalBytesProcessed = defaultValueIfNull(qr.getTotalBytesProcessed(), 0L);
                     TableSchema schema = defaultValueIfNull(qr.getSchema(), new TableSchema());
-                    return new BQScrollableResultSet(qr.getRows(), this, schema, totalBytesProcessed, cacheHit);
+                    return new BQScrollableResultSet(qr.getRows(), this, schema, qr.getTotalBytesProcessed(), qr.getCacheHit());
                 }
                 jobAlreadyCompleted = true;
             }
@@ -235,6 +233,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
                 if (jobAlreadyCompleted) {
                     status = "DONE";
                 } else {
+                    if (referencedJob == null) {
+                        throw new BQSQLException("Cannot poll results without a job reference");
+                    }
                     try {
                         status = BQSupportFuncts.getQueryState(referencedJob,
                                 this.connection.getBigquery(),
@@ -252,6 +253,9 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
 
                 if (status.equals("DONE")) {
                     if (resultSetType == ResultSet.TYPE_SCROLL_INSENSITIVE) {
+                        if (referencedJob == null) {
+                            throw new BQSQLException("Cannot poll results without a job reference");
+                        }
                         return new BQScrollableResultSet(BQSupportFuncts.getQueryResults(
                                 this.connection.getBigquery(),
                                 projectId,

--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatementRoot.java
@@ -341,10 +341,8 @@ public abstract class BQStatementRoot {
             if (defaultValueIfNull(qr.getJobComplete(), false)) {
                 List<TableRow> rows = defaultValueIfNull(qr.getRows(), new ArrayList<TableRow>());
                 if (BigInteger.valueOf(rows.size()).equals(qr.getTotalRows())) {
-                    Boolean cacheHit = defaultValueIfNull(qr.getCacheHit(), false);
-                    Long totalBytesProcessed = defaultValueIfNull(qr.getTotalBytesProcessed(), 0L);
                     TableSchema schema = defaultValueIfNull(qr.getSchema(), new TableSchema());
-                    return new BQScrollableResultSet(rows, this, schema, totalBytesProcessed, cacheHit);
+                    return new BQScrollableResultSet(rows, this, schema, qr.getTotalBytesProcessed(), qr.getCacheHit());
                 }
                 jobAlreadyCompleted = true;
             }

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -663,7 +663,7 @@ public class BQForwardOnlyResultSetFunctionTest {
         try {
             mockResponse("{}");
         } catch (BQSQLException e) {
-            Assert.assertTrue(e.getMessage().contains("no job reference"));
+            Assert.assertTrue(e.getMessage().contains("without a job reference"));
             return;
         }
         throw new AssertionError("Expected graceful failure due to lack of job reference");

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -24,6 +24,9 @@
  */
 package net.starschema.clouddb.jdbc;
 
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import java.io.IOException;
@@ -594,7 +597,8 @@ public class BQForwardOnlyResultSetFunctionTest {
         QueryLoad();
         Assert.assertTrue(resultForTest instanceof BQForwardOnlyResultSet);
         BQForwardOnlyResultSet results = (BQForwardOnlyResultSet)resultForTest;
-        Assert.assertEquals(results.getTotalBytesProcessed() == 0, results.getCacheHit());
+        final Boolean processedNoBytes = new Long(0L).equals(results.getTotalBytesProcessed());
+        Assert.assertEquals(processedNoBytes, results.getCacheHit());
     }
 
 	@Test
@@ -652,5 +656,46 @@ public class BQForwardOnlyResultSetFunctionTest {
             stmt.setQueryTimeout(500);
             stmt.executeQuery(cleanupSql);
         }
+    }
+
+    @Test
+    public void testHandlesAllNullResponseFields() throws Exception {
+        try {
+            mockResponse("{}");
+        } catch (BQSQLException e) {
+            Assert.assertTrue(e.getMessage().contains("no job reference"));
+            return;
+        }
+        throw new AssertionError("Expected graceful failure due to lack of job reference");
+    }
+
+    @Test
+    public void testHandlesSomeNullResponseFields() throws Exception {
+        // Make sure we don't get any NPE's due to null values;
+        mockResponse(
+            "{ \"jobComplete\": true, "
+            + "\"totalRows\": \"0\", "
+            + "\"rows\": [] }");
+    }
+
+    private void mockResponse(String jsonResponse) throws Exception {
+        Properties properties =
+            BQSupportFuncts.readFromPropFile(
+                getClass().getResource("/installedaccount.properties").getFile());
+        String url = BQSupportFuncts.constructUrlFromPropertiesFile(properties, true, null);
+        // Mock an empty response object.
+        MockHttpTransport mockTransport =
+            new MockHttpTransport.Builder()
+                .setLowLevelHttpResponse(
+                    new MockLowLevelHttpResponse().setContent(jsonResponse))
+                .build();
+        BQConnection bq = new BQConnection(url + "&useLegacySql=false", properties, mockTransport);
+        BQStatement stmt = new BQStatement(properties.getProperty("projectid"), bq, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        String sqlStmt = "SELECT word from publicdata:samples.shakespeare LIMIT 100";
+
+        BQForwardOnlyResultSet results = ((BQForwardOnlyResultSet)stmt.executeQuery(sqlStmt));
+
+        results.getTotalBytesProcessed();
+        results.getCacheHit();
     }
 }

--- a/src/test/java/net/starschema/clouddb/jdbc/BQScrollableResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQScrollableResultSetFunctionTest.java
@@ -24,10 +24,15 @@
  */
 package net.starschema.clouddb.jdbc;
 
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 import junit.framework.Assert;
 
@@ -722,7 +727,48 @@ public class BQScrollableResultSetFunctionTest {
     public void TestResultSetTotalBytesProcessedCacheHit() {
         Assert.assertTrue(Result instanceof BQScrollableResultSet);
         BQScrollableResultSet results = (BQScrollableResultSet)Result;
-        Assert.assertEquals(results.getTotalBytesProcessed() == 0, results.getCacheHit());
+        final Boolean processedNoBytes = new Long(0L).equals(results.getTotalBytesProcessed());
+        Assert.assertEquals(processedNoBytes, results.getCacheHit());
     }
 
+    @Test
+    public void testHandlesAllNullResponseFields() throws Exception {
+        try {
+            mockResponse("{}");
+        } catch (BQSQLException e) {
+            Assert.assertTrue(e.getMessage().contains("no job reference"));
+            return;
+        }
+        throw new AssertionError("Expected graceful failure due to lack of job reference");
+    }
+
+    @Test
+    public void testHandlesSomeNullResponseFields() throws Exception {
+        // Make sure we don't get any NPE's due to null values;
+        mockResponse(
+            "{ \"jobComplete\": true, "
+            + "\"totalRows\": \"0\", "
+            + "\"rows\": [] }");
+    }
+
+    private void mockResponse(String jsonResponse) throws Exception {
+        Properties properties =
+            BQSupportFuncts.readFromPropFile(
+                getClass().getResource("/installedaccount.properties").getFile());
+        String url = BQSupportFuncts.constructUrlFromPropertiesFile(properties, true, null);
+        // Mock an empty response object.
+        MockHttpTransport mockTransport =
+            new MockHttpTransport.Builder()
+                .setLowLevelHttpResponse(
+                    new MockLowLevelHttpResponse().setContent(jsonResponse))
+                .build();
+        BQConnection bq = new BQConnection(url + "&useLegacySql=false", properties, mockTransport);
+        BQStatement stmt = new BQStatement(properties.getProperty("projectid"), bq, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+        String sqlStmt = "SELECT word from publicdata:samples.shakespeare LIMIT 100";
+
+        BQScrollableResultSet results = ((BQScrollableResultSet)stmt.executeQuery(sqlStmt));
+
+        results.getTotalBytesProcessed();
+        results.getCacheHit();
+    }
 }

--- a/src/test/java/net/starschema/clouddb/jdbc/BQScrollableResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQScrollableResultSetFunctionTest.java
@@ -736,7 +736,7 @@ public class BQScrollableResultSetFunctionTest {
         try {
             mockResponse("{}");
         } catch (BQSQLException e) {
-            Assert.assertTrue(e.getMessage().contains("no job reference"));
+            Assert.assertTrue(e.getMessage().contains("without a job reference"));
             return;
         }
         throw new AssertionError("Expected graceful failure due to lack of job reference");


### PR DESCRIPTION
Being null can be significant, especially in light of row-level ACLs, for which `totalBytesProcessed` is set to null to prevent users from inferring things they shouldn't know about the table. Let's just let the total bytes processed and cache hit metrics be null. We'll just neglect to emit the Pinger metrics in Looker if they're null.

Also add some more tests. Testing null-readiness is really annoying since so many things can be null. Open to suggestions on how I might test this better.