### PR TITLE
Upgrade google clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,17 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.25.0</version>
+      <version>1.32.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson</artifactId>
-      <version>1.25.0</version>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>1.39.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>

--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -23,7 +23,7 @@
 package net.starschema.clouddb.jdbc;
 
 import com.google.api.client.json.JsonGenerator;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.util.Data;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.*;


### PR DESCRIPTION
Switches from the authentication in
com.google.api.client.googleapis.auth.oauth2.GoogleCredential to
com.google.auth.oauth2.GoogleCredentials.  The former is deprecated and
does not support the newer authentication mechanisms that the latter
does.  This switch should let us use the latest authentication
mechanisms specified in the google credentials json file, such as
external authentication.