### PR TITLE
Enforce spotless check during validate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,10 +215,19 @@
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
         <version>2.12.2</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
         <configuration>
           <java>
             <googleJavaFormat>
-              <version>1.11.0</version>
+              <!-- Latest version which runs on java8 -->
+              <version>1.7</version>
               <style>GOOGLE</style>
             </googleJavaFormat>
           </java>

--- a/src/main/java/net/starschema/clouddb/jdbc/DMDResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/DMDResultSet.java
@@ -485,7 +485,7 @@ public class DMDResultSet extends ScrollableResultset<Object> implements java.sq
   public void close() throws SQLException {
     super.close();
     this.Colnames = null;
-  };
+  }
 
   /** {@inheritDoc} */
   @Override
@@ -506,7 +506,7 @@ public class DMDResultSet extends ScrollableResultset<Object> implements java.sq
   @Override
   public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
     throw new BQSQLException("Not implemented.");
-  };
+  }
 
   /**
    *

--- a/src/main/java/net/starschema/clouddb/jdbc/DMDResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/DMDResultSet.java
@@ -485,8 +485,7 @@ public class DMDResultSet extends ScrollableResultset<Object> implements java.sq
   public void close() throws SQLException {
     super.close();
     this.Colnames = null;
-  }
-  ;
+  };
 
   /** {@inheritDoc} */
   @Override
@@ -507,8 +506,7 @@ public class DMDResultSet extends ScrollableResultset<Object> implements java.sq
   @Override
   public <T> T getObject(String columnLabel, Class<T> type) throws SQLException {
     throw new BQSQLException("Not implemented.");
-  }
-  ;
+  };
 
   /**
    *


### PR DESCRIPTION
I added spotless to maven previously, but forgot to include it in the `verify` step.  This ensures that it will cause CI to fail if bad changes are checked in.