### PR TITLE
[b/198504533] Adds support for Application Default Credentials flag as URL param

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,11 @@ jobs:
           echo "$PROTECTEDACCOUNT_PROPERTIES" > src/test/resources/protectedaccount.properties
           echo "$SERVICE_ACCOUNT_PROPERTIES" > src/test/resources/serviceaccount.properties
           echo "$OAUTHACCOUNT_PROPERTIES" > src/test/resources/oauthaccount.properties
+          echo "GOOGLE_APPLICATION_CREDENTIALS set to: $GOOGLE_APPLICATION_CREDENTIALS"
           echo "Secrets loaded!"
         shell: bash
         env:
+          GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json
           BIGQUERY_CREDENTIALS_P12: ${{ secrets.BIGQUERY_CREDENTIALS_P12 }}
           BIGQUERY_CREDENTIALS_PROTECTED_JSON: ${{ secrets.BIGQUERY_CREDENTIALS_PROTECTED_JSON }}
           BIGQUERY_CREDENTIALS_PROTECTED_P12: ${{ secrets.BIGQUERY_CREDENTIALS_PROTECTED_P12 }}
@@ -39,7 +41,6 @@ jobs:
           PROTECTEDACCOUNT_PROPERTIES: ${{ secrets.PROTECTEDACCOUNT_PROPERTIES }}
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
-          GOOGLE_APPLICATION_CREDENTIALS: "src/test/resources/bigquery_credentials_protected.json"
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - run: mkdir staging && cp target/*.jar staging

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
       - name: Build with Maven
         env: 
-          GOOGLE_APPLICATION_CREDENTIALS: $HOME/bqjdbc/src/test/resources/bigquery_credentials_protected.json
+          GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json
         run: mvn -B package --file pom.xml
       - run: mkdir staging && cp target/*.jar staging
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
           PROTECTEDACCOUNT_PROPERTIES: ${{ secrets.PROTECTEDACCOUNT_PROPERTIES }}
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
+          GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - run: mkdir staging && cp target/*.jar staging

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           echo "Secrets loaded!"
         shell: bash
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json
+          GOOGLE_APPLICATION_CREDENTIALS: ~/bqjdbc/src/test/resources/bigquery_credentials_protected.json
           BIGQUERY_CREDENTIALS_P12: ${{ secrets.BIGQUERY_CREDENTIALS_P12 }}
           BIGQUERY_CREDENTIALS_PROTECTED_JSON: ${{ secrets.BIGQUERY_CREDENTIALS_PROTECTED_JSON }}
           BIGQUERY_CREDENTIALS_PROTECTED_P12: ${{ secrets.BIGQUERY_CREDENTIALS_PROTECTED_P12 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,9 @@ jobs:
           echo "$PROTECTEDACCOUNT_PROPERTIES" > src/test/resources/protectedaccount.properties
           echo "$SERVICE_ACCOUNT_PROPERTIES" > src/test/resources/serviceaccount.properties
           echo "$OAUTHACCOUNT_PROPERTIES" > src/test/resources/oauthaccount.properties
-          echo "GOOGLE_APPLICATION_CREDENTIALS set to: $GOOGLE_APPLICATION_CREDENTIALS"
           echo "Secrets loaded!"
         shell: bash
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ~/bqjdbc/src/test/resources/bigquery_credentials_protected.json
           BIGQUERY_CREDENTIALS_P12: ${{ secrets.BIGQUERY_CREDENTIALS_P12 }}
           BIGQUERY_CREDENTIALS_PROTECTED_JSON: ${{ secrets.BIGQUERY_CREDENTIALS_PROTECTED_JSON }}
           BIGQUERY_CREDENTIALS_PROTECTED_P12: ${{ secrets.BIGQUERY_CREDENTIALS_PROTECTED_P12 }}
@@ -42,6 +40,8 @@ jobs:
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
       - name: Build with Maven
+        env: 
+          GOOGLE_APPLICATION_CREDENTIALS: $HOME/bqjdbc/src/test/resources/bigquery_credentials_protected.json
         run: mvn -B package --file pom.xml
       - run: mkdir staging && cp target/*.jar staging
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           PROTECTEDACCOUNT_PROPERTIES: ${{ secrets.PROTECTEDACCOUNT_PROPERTIES }}
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
-          GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json
+          GOOGLE_APPLICATION_CREDENTIALS: "src/test/resources/bigquery_credentials_protected.json"
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - run: mkdir staging && cp target/*.jar staging

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -161,6 +161,11 @@ public class BQConnection implements Connection {
     boolean serviceAccount =
         parseBooleanQueryParam(caseInsensitiveProps.getProperty("withserviceaccount"), false);
 
+    // extract withApplicationDefaultCredentials
+    boolean applicationDefaultCredentials =
+        parseBooleanQueryParam(
+            caseInsensitiveProps.getProperty("withapplicationdefaultcredentials"), false);
+
     // extract useLegacySql property
     this.useLegacySql =
         parseBooleanQueryParam(caseInsensitiveProps.getProperty("uselegacysql"), false);
@@ -231,6 +236,14 @@ public class BQConnection implements Connection {
                 oAuthAccessToken, userAgent, connectTimeout, readTimeout, rootUrl, httpTransport);
         this.logger.info("Authorized with OAuth access token");
       } catch (SQLException e) {
+        throw new BQSQLException(e);
+      }
+    } else if (applicationDefaultCredentials) {
+      try {
+        this.bigquery =
+            Oauth2Bigquery.authorizeViaApplicationDefault(
+                userAgent, connectTimeout, readTimeout, rootUrl, httpTransport);
+      } catch (IOException e) {
         throw new BQSQLException(e);
       }
     } else {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -117,6 +117,13 @@ public class BQSupportFuncts {
       } else {
         return null;
       }
+    } else if (properties.getProperty("type").equals("applicationDefault")) {
+      forreturn =
+          BQDriver.getURLPrefix()
+              + URLEncoder.encode(projectId, "UTF-8")
+              + (dataset != null && full ? "/" + URLEncoder.encode(dataset, "UTF-8") : "")
+              + "?withApplicationDefaultCredentials=true";
+      paramSep = "&";
     } else {
       return null;
     }

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -182,6 +182,17 @@ public class JdbcUrlTest {
   }
 
   @Test
+  public void canConnectWithApplicationDefaultCredentials() throws SQLException, IOException {
+    // generate access token from Application Default Credentials
+    Properties defaultProps = getProperties("/applicationdefault.properties");
+    String url = BQSupportFuncts.constructUrlFromPropertiesFile(defaultProps, true, null);
+    BQConnection bqConn = new BQConnection(url, new Properties());
+
+    BQStatement stmt = new BQStatement(defaultProps.getProperty("projectid"), bqConn);
+    stmt.executeQuery("SELECT * FROM orders limit 1");
+  }
+
+  @Test
   public void gettingUrlComponentsWorks() throws IOException {
     String url = getUrl("/protectedaccount.properties", null);
     Properties protectedProperties = getProperties("/protectedaccount.properties");

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -183,12 +183,17 @@ public class JdbcUrlTest {
 
   @Test
   public void canConnectWithApplicationDefaultCredentials() throws SQLException, IOException {
-    // generate access token from Application Default Credentials
-    Properties defaultProps = getProperties("/applicationdefault.properties");
-    String url = BQSupportFuncts.constructUrlFromPropertiesFile(defaultProps, true, null);
+    // For testing, the `GOOGLE_APPLICATION_ENVIRONMENT` env var is a path to a service account file
+    Properties testProps = getProperties("/protectedaccount-json.properties");
+    String url =
+        BQDriver.getURLPrefix()
+            + testProps.getProperty("projectid")
+            + "/"
+            + testProps.getProperty("dataset");
+    url += "?withApplicationDefaultCredentials=true";
     BQConnection bqConn = new BQConnection(url, new Properties());
 
-    BQStatement stmt = new BQStatement(defaultProps.getProperty("projectid"), bqConn);
+    BQStatement stmt = new BQStatement(bqConn.getProjectId(), bqConn);
     stmt.executeQuery("SELECT * FROM orders limit 1");
   }
 


### PR DESCRIPTION
Adds support for `withApplicationDefaultCredentials` param that will use the [application default credential](https://cloud.google.com/docs/authentication/production#automatically) to authenticate a BQ connection. This param takes the lowest precedence over other auth methods if multiple are provided for some reason:

 1) `withServiceAccount` - use service account file.
 2) `oAuthAccessToken` - use the provided OAuth token.
 3) `withApplicationDefaultCredentials` - use application default.

This is part 1 of 2 to assist in adding service account impersonation to Looker.


**NOTE**: Tests will almost certainly fail due the public `shakespeare` dataset being out of commission as of earlier today Most of our tests use this dataset to here's hoping that gets resolved soon.