### PR TITLE
Adds support for service account impersonation 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           echo "$PROTECTEDACCOUNT_PROPERTIES" > src/test/resources/protectedaccount.properties
           echo "$SERVICE_ACCOUNT_PROPERTIES" > src/test/resources/serviceaccount.properties
           echo "$OAUTHACCOUNT_PROPERTIES" > src/test/resources/oauthaccount.properties
+          echo "$APPLICATION_DEFAULT_PROPERTIES" > src/test/resources/applicationdefault.properties
           echo "Secrets loaded!"
         shell: bash
         env:
@@ -39,6 +40,7 @@ jobs:
           PROTECTEDACCOUNT_PROPERTIES: ${{ secrets.PROTECTEDACCOUNT_PROPERTIES }}
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
+          APPLICATION_DEFAULT_PROPERTIES: ${{ secrets.APPLICATION_DEFAULT_PROPERTIES }}
       - name: Build with Maven
         env: 
           GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -155,6 +155,7 @@ public class BQConnection implements Connection {
     String userKey = caseInsensitiveProps.getProperty("password");
     String userPath = caseInsensitiveProps.getProperty("path");
 
+    String targetServiceAccount = caseInsensitiveProps.getProperty("targetserviceaccount");
     String oAuthAccessToken = caseInsensitiveProps.getProperty("oauthaccesstoken");
 
     // extract withServiceAccount property
@@ -222,7 +223,8 @@ public class BQConnection implements Connection {
                 readTimeout,
                 connectTimeout,
                 rootUrl,
-                httpTransport);
+                httpTransport,
+                targetServiceAccount);
         this.logger.info("Authorized with service account");
       } catch (GeneralSecurityException e) {
         throw new BQSQLException(e);
@@ -233,7 +235,13 @@ public class BQConnection implements Connection {
       try {
         this.bigquery =
             Oauth2Bigquery.authorizeViaToken(
-                oAuthAccessToken, userAgent, connectTimeout, readTimeout, rootUrl, httpTransport);
+                oAuthAccessToken,
+                userAgent,
+                connectTimeout,
+                readTimeout,
+                rootUrl,
+                httpTransport,
+                targetServiceAccount);
         this.logger.info("Authorized with OAuth access token");
       } catch (SQLException e) {
         throw new BQSQLException(e);
@@ -242,7 +250,12 @@ public class BQConnection implements Connection {
       try {
         this.bigquery =
             Oauth2Bigquery.authorizeViaApplicationDefault(
-                userAgent, connectTimeout, readTimeout, rootUrl, httpTransport);
+                userAgent,
+                connectTimeout,
+                readTimeout,
+                rootUrl,
+                httpTransport,
+                targetServiceAccount);
       } catch (IOException e) {
         throw new BQSQLException(e);
       }

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -87,7 +87,7 @@ public class Oauth2Bigquery {
 
   private static final String DRIVE_SCOPE = "https://www.googleapis.com/auth/drive";
 
-  private static final Integer MAX_IMPERSONATION_LIFETIME = 43200;
+  private static final Integer DEFAULT_IMPERSONATION_LIFETIME = 3600;
 
   /**
    * Creates a Bigquery.Builder using the provided GoogleCredential
@@ -385,7 +385,7 @@ public class Oauth2Bigquery {
         targetServiceAccount,
         null, // Look into delegates later if necessary
         GenerateScopes(false),
-        MAX_IMPERSONATION_LIFETIME);
+        DEFAULT_IMPERSONATION_LIFETIME);
   }
 
   private static GoogleCredentials createServiceAccountCredential(

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -184,7 +184,7 @@ public class JdbcUrlTest {
   @Test
   public void canConnectWithApplicationDefaultCredentials() throws SQLException, IOException {
     // For testing, the `GOOGLE_APPLICATION_ENVIRONMENT` env var is a path to a service account file
-    Properties testProps = getProperties("/protectedaccount-json.properties");
+    Properties testProps = getProperties("/applicationdefault.properties");
     String url =
         BQDriver.getURLPrefix()
             + testProps.getProperty("projectid")
@@ -200,14 +200,15 @@ public class JdbcUrlTest {
   @Test
   public void canImpersonateServiceAccountWithApplicationDefaultAsSource()
       throws IOException, SQLException {
-    Properties testProps = getProperties("/protectedaccount-json.properties");
+    Properties testProps = getProperties("/applicationdefault.properties");
     String url =
         BQDriver.getURLPrefix()
             + testProps.getProperty("projectid")
             + "/"
             + testProps.getProperty("dataset");
-    String targetServiceAccount = "looker-service-account@looker-test-db.iam.gserviceaccount.com";
-    url += "?withApplicationDefaultCredentials=true&targetServiceAccount=" + targetServiceAccount;
+    url +=
+        "?withApplicationDefaultCredentials=true&targetServiceAccount="
+            + testProps.getProperty("targetaccount");
     BQConnection bqConn = new BQConnection(url, new Properties());
 
     BQStatement stmt = new BQStatement(bqConn.getProjectId(), bqConn);
@@ -217,15 +218,16 @@ public class JdbcUrlTest {
   @Test
   public void impersonatingServiceAccountWithLimitedPermissionsWorksAsExpected()
       throws IOException, SQLException {
-    Properties testProps = getProperties("/protectedaccount-json.properties");
+    Properties testProps = getProperties("/applicationdefault.properties");
     String url =
         BQDriver.getURLPrefix()
             + testProps.getProperty("projectid")
             + "/"
             + testProps.getProperty("dataset");
     // dummy service account that has the BigQuery User role but no access to the orders table
-    String targetServiceAccount = "limited-bq-access@looker-test-db.iam.gserviceaccount.com";
-    url += "?withApplicationDefaultCredentials=true&targetServiceAccount=" + targetServiceAccount;
+    url +=
+        "?withApplicationDefaultCredentials=true&targetServiceAccount="
+            + testProps.getProperty("limitedpermissiontargetaccount");
     BQConnection bqConn = new BQConnection(url, new Properties());
 
     BQStatement stmt = new BQStatement(bqConn.getProjectId(), bqConn);

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -198,6 +198,22 @@ public class JdbcUrlTest {
   }
 
   @Test
+  public void canImpersonateServiceAccountWithApplicationDefaultAsSource()
+      throws IOException, SQLException {
+    Properties testProps = getProperties("/protectedaccount-json.properties");
+    String url =
+        BQDriver.getURLPrefix()
+            + testProps.getProperty("projectid")
+            + "/"
+            + testProps.getProperty("dataset");
+    url += "?withApplicationDefaultCredentials=true&targetServiceAccount=tjbanghart@google.com";
+    BQConnection bqConn = new BQConnection(url, new Properties());
+
+    BQStatement stmt = new BQStatement(bqConn.getProjectId(), bqConn);
+    stmt.executeQuery("SELECT * FROM orders limit 1");
+  }
+
+  @Test
   public void gettingUrlComponentsWorks() throws IOException {
     String url = getUrl("/protectedaccount.properties", null);
     Properties protectedProperties = getProperties("/protectedaccount.properties");


### PR DESCRIPTION
Adds a new URL param `targetServiceAccount=<String>` to allow for [service account "impersonation"](https://cloud.google.com/iam/docs/impersonating-service-accounts) e.g. `targetServiceAccount=<service-account>@<project>.iam.gserviceaccount.com` 

Choosing an auth method is still required so, for example, `withApplicationDefaultCredentials=true&targetServiceAccount=<service-account-email>` would use the application default as source and attempt to impersonate the target account.

This should work fine for `withServiceAccount` and `withApplicationDefaultCredentials`. I _think_ this should be fine for `oAuthAccessToken` also but I have yet to verify (should probably do that). 

One thing to note, the [docs](https://cloud.google.com/iam/docs/impersonating-service-accounts#allow-impersonation) mention a few IAM roles that would allow impersonation. For the purposes of this driver, the `Service Account Token Creator` role is the one to use -- it should be granted to the _source_ credential and the IAM Service Account APIs need to be enabled for the project. The target account will need the appropriate BigQuery permissions to access the desired project/dataset/tables.
