### PR TITLE
Set default application credentials path for test runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,6 @@ jobs:
           SERVICE_ACCOUNT_PROPERTIES: ${{ secrets.SERVICE_ACCOUNT_PROPERTIES }}
           OAUTHACCOUNT_PROPERTIES: ${{ secrets.OAUTHACCOUNT_PROPERTIES }}
       - name: Build with Maven
-        env: 
-          GOOGLE_APPLICATION_CREDENTIALS: src/test/resources/bigquery_credentials_protected.json
         run: mvn -B package --file pom.xml
       - run: mkdir staging && cp target/*.jar staging
       - uses: actions/upload-artifact@v2

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,12 @@
       <version>1.7.30</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.19.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- END TEST DEPENDENCIES -->
   </dependencies>
   <build>

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -15,7 +15,9 @@ import java.util.Properties;
 import junit.framework.Assert;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 /** Created by steven on 10/21/15. */
 public class JdbcUrlTest {
@@ -23,6 +25,10 @@ public class JdbcUrlTest {
   private BQConnection bq;
   private String URL;
   private Properties properties;
+  private final String defaultServiceAccount =
+      "src/test/resources/bigquery_credentials_protected.json";
+
+  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @Before
   public void setup() throws SQLException, IOException {
@@ -30,6 +36,7 @@ public class JdbcUrlTest {
     URL = getUrl("/installedaccount.properties", null) + "&useLegacySql=true";
     ;
     this.bq = new BQConnection(URL, new Properties());
+    this.environmentVariables.set("GOOGLE_APPLICATION_CREDENTIALS", defaultServiceAccount);
   }
 
   @Test


### PR DESCRIPTION
Sets the `GOOGLE_APPLICATION_CREDENTIALS` environment variable for the `JdbcUrlTest` class so tests that need it are guaranteed to have it set.