### PR TITLE
Adds support for SA delegates with impersonation.

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -315,13 +315,10 @@ public class BQConnection implements Connection {
    * Return null if {@code string} is null. Otherwise, return an array of delegates iff {@code
    * string} can be parsed as an array when split by {@code delimiter}.
    */
-  private static List<String> parseArrayQueryParam(@Nullable String string, Character delimiter)
-      throws BQSQLException {
-    List<String> delegates = null;
-    if (string != null) {
-      delegates = Arrays.asList(string.split("\\s*" + delimiter + "\\s*"));
-    }
-    return delegates;
+  private static List<String> parseArrayQueryParam(@Nullable String string, Character delimiter) {
+    return string == null
+        ? Collections.emptyList()
+        : Arrays.asList(string.split("\\s*" + delimiter + "\\s*"));
   }
 
   /**

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -310,7 +310,7 @@ public class BQConnection implements Connection {
   }
 
   /**
-   * Return an empty list if {@code string} is null. Otherwise, return an array of delegates iff
+   * Return an empty list if {@code string} is null. Otherwise, return an array of strings iff
    * {@code string} can be parsed as an array when split by {@code delimiter}.
    */
   private static List<String> parseArrayQueryParam(@Nullable String string, Character delimiter) {

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -155,13 +155,14 @@ public class BQConnection implements Connection {
     String userKey = caseInsensitiveProps.getProperty("password");
     String userPath = caseInsensitiveProps.getProperty("path");
 
+    // extract a list of "delegate" service accounts leading to a "target" service account to use
+    // for impersonation.
+    // if only a single service account is provided, then it will be used as the "target"
     List<String> targetServiceAccounts =
         parseArrayQueryParam(caseInsensitiveProps.getProperty("targetserviceaccount"), ',');
-    String oAuthAccessToken = caseInsensitiveProps.getProperty("oauthaccesstoken");
 
-    // extract a list of delegates if provided, should be a list of comma seperated SA emails
-    List<String> delegates =
-        parseArrayQueryParam(caseInsensitiveProps.getProperty("delegates"), ',');
+    // extract OAuth access token
+    String oAuthAccessToken = caseInsensitiveProps.getProperty("oauthaccesstoken");
 
     // extract withServiceAccount property
     boolean serviceAccount =

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -156,8 +156,7 @@ public class BQConnection implements Connection {
     String userPath = caseInsensitiveProps.getProperty("path");
 
     // extract a list of "delegate" service accounts leading to a "target" service account to use
-    // for impersonation.
-    // if only a single service account is provided, then it will be used as the "target"
+    // for impersonation. if only a single account is provided, then it will be used as the "target"
     List<String> targetServiceAccounts =
         parseArrayQueryParam(caseInsensitiveProps.getProperty("targetserviceaccount"), ',');
 

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -155,7 +155,8 @@ public class BQConnection implements Connection {
     String userKey = caseInsensitiveProps.getProperty("password");
     String userPath = caseInsensitiveProps.getProperty("path");
 
-    String targetServiceAccount = caseInsensitiveProps.getProperty("targetserviceaccount");
+    List<String> targetServiceAccounts =
+        parseArrayQueryParam(caseInsensitiveProps.getProperty("targetserviceaccount"), ',');
     String oAuthAccessToken = caseInsensitiveProps.getProperty("oauthaccesstoken");
 
     // extract a list of delegates if provided, should be a list of comma seperated SA emails
@@ -228,8 +229,7 @@ public class BQConnection implements Connection {
                 connectTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccount,
-                delegates);
+                targetServiceAccounts);
         this.logger.info("Authorized with service account");
       } catch (GeneralSecurityException e) {
         throw new BQSQLException(e);
@@ -246,8 +246,7 @@ public class BQConnection implements Connection {
                 readTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccount,
-                delegates);
+                targetServiceAccounts);
         this.logger.info("Authorized with OAuth access token");
       } catch (SQLException e) {
         throw new BQSQLException(e);
@@ -261,8 +260,7 @@ public class BQConnection implements Connection {
                 readTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccount,
-                delegates);
+                targetServiceAccounts);
       } catch (IOException e) {
         throw new BQSQLException(e);
       }
@@ -312,8 +310,8 @@ public class BQConnection implements Connection {
   }
 
   /**
-   * Return null if {@code string} is null. Otherwise, return an array of delegates iff {@code
-   * string} can be parsed as an array when split by {@code delimiter}.
+   * Return an empty list if {@code string} is null. Otherwise, return an array of delegates iff
+   * {@code string} can be parsed as an array when split by {@code delimiter}.
    */
   private static List<String> parseArrayQueryParam(@Nullable String string, Character delimiter) {
     return string == null

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -316,7 +316,7 @@ public class BQConnection implements Connection {
   private static List<String> parseArrayQueryParam(@Nullable String string, Character delimiter) {
     return string == null
         ? Collections.emptyList()
-        : Arrays.asList(string.split("\\s*" + delimiter + "\\s*"));
+        : Arrays.asList(string.split(delimiter + "\\s*"));
   }
 
   /**

--- a/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQConnection.java
@@ -158,6 +158,10 @@ public class BQConnection implements Connection {
     String targetServiceAccount = caseInsensitiveProps.getProperty("targetserviceaccount");
     String oAuthAccessToken = caseInsensitiveProps.getProperty("oauthaccesstoken");
 
+    // extract a list of delegates if provided, should be a list of comma seperated SA emails
+    List<String> delegates =
+        parseArrayQueryParam(caseInsensitiveProps.getProperty("delegates"), ',');
+
     // extract withServiceAccount property
     boolean serviceAccount =
         parseBooleanQueryParam(caseInsensitiveProps.getProperty("withserviceaccount"), false);
@@ -224,7 +228,8 @@ public class BQConnection implements Connection {
                 connectTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccount);
+                targetServiceAccount,
+                delegates);
         this.logger.info("Authorized with service account");
       } catch (GeneralSecurityException e) {
         throw new BQSQLException(e);
@@ -241,7 +246,8 @@ public class BQConnection implements Connection {
                 readTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccount);
+                targetServiceAccount,
+                delegates);
         this.logger.info("Authorized with OAuth access token");
       } catch (SQLException e) {
         throw new BQSQLException(e);
@@ -255,7 +261,8 @@ public class BQConnection implements Connection {
                 readTimeout,
                 rootUrl,
                 httpTransport,
-                targetServiceAccount);
+                targetServiceAccount,
+                delegates);
       } catch (IOException e) {
         throw new BQSQLException(e);
       }
@@ -302,6 +309,19 @@ public class BQConnection implements Connection {
       }
     }
     return val;
+  }
+
+  /**
+   * Return null if {@code string} is null. Otherwise, return an array of delegates iff {@code
+   * string} can be parsed as an array when split by {@code delimiter}.
+   */
+  private static List<String> parseArrayQueryParam(@Nullable String string, Character delimiter)
+      throws BQSQLException {
+    List<String> delegates = null;
+    if (string != null) {
+      delegates = Arrays.asList(string.split("\\s*" + delimiter + "\\s*"));
+    }
+    return delegates;
   }
 
   /**

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -104,10 +104,11 @@ public class Oauth2Bigquery {
       String userAgent,
       String rootUrl,
       String targetServiceAccount,
-      @Nullable String oauthToken) {
+      @Nullable String oauthToken,
+      @Nullable List<String> delegates) {
 
     if (targetServiceAccount != null) {
-      credential = impersonateServiceAccount(credential, targetServiceAccount);
+      credential = impersonateServiceAccount(credential, targetServiceAccount, delegates);
     }
 
     HttpRequestTimeoutInitializer httpRequestInitializer =
@@ -171,7 +172,8 @@ public class Oauth2Bigquery {
       Integer readTimeout,
       String rootUrl,
       HttpTransport httpTransport,
-      String targetServiceAccount)
+      String targetServiceAccount,
+      List<String> delegates)
       throws SQLException {
     GoogleCredentials credential = GoogleCredentials.create(new AccessToken(oauthToken, null));
 
@@ -186,7 +188,8 @@ public class Oauth2Bigquery {
             userAgent,
             rootUrl,
             targetServiceAccount,
-            oauthToken);
+            oauthToken,
+            delegates);
 
     return new MinifiedBigquery(bqBuilder);
   }
@@ -278,7 +281,8 @@ public class Oauth2Bigquery {
       Integer connectTimeout,
       String rootUrl,
       HttpTransport httpTransport,
-      String targetServiceAccount)
+      String targetServiceAccount,
+      List<String> delegates)
       throws GeneralSecurityException, IOException {
     GoogleCredentials credential =
         createServiceAccountCredential(
@@ -295,7 +299,8 @@ public class Oauth2Bigquery {
             userAgent,
             rootUrl,
             targetServiceAccount,
-            null);
+            null,
+            delegates);
 
     return new MinifiedBigquery(bqBuilder);
   }
@@ -330,7 +335,8 @@ public class Oauth2Bigquery {
       Integer readTimeout,
       String rootUrl,
       HttpTransport httpTransport,
-      String targetServiceAccount)
+      String targetServiceAccount,
+      List<String> delegates)
       throws IOException {
     GoogleCredentials credential = GoogleCredentials.getApplicationDefault();
 
@@ -345,7 +351,8 @@ public class Oauth2Bigquery {
             userAgent,
             rootUrl,
             targetServiceAccount,
-            null);
+            null,
+            delegates);
 
     return new MinifiedBigquery(bqBuilder);
   }
@@ -388,12 +395,14 @@ public class Oauth2Bigquery {
   }
 
   private static GoogleCredentials impersonateServiceAccount(
-      GoogleCredentials sourceCredentials, String targetServiceAccount) {
+      GoogleCredentials sourceCredentials,
+      String targetServiceAccount,
+      @Nullable List<String> delegates) {
 
     return ImpersonatedCredentials.create(
         sourceCredentials,
         targetServiceAccount,
-        null, // Look into delegates later if necessary
+        delegates,
         GenerateScopes(false),
         DEFAULT_IMPERSONATION_LIFETIME);
   }

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -106,9 +106,8 @@ public class Oauth2Bigquery {
       List<String> targetServiceAccounts,
       @Nullable String oauthToken) {
 
-    if (!targetServiceAccounts.isEmpty()) {
-      credential = impersonateServiceAccount(credential, targetServiceAccounts);
-    }
+    // If targetServiceAccounts is empty this returns the original credential
+    credential = impersonateServiceAccount(credential, targetServiceAccounts);
 
     HttpRequestTimeoutInitializer httpRequestInitializer =
         createRequestTimeoutInitalizer(credential, connectTimeout, readTimeout);
@@ -387,8 +386,22 @@ public class Oauth2Bigquery {
     return response.getAccessToken();
   }
 
+  /**
+   * If {@code targetServiceAccounts} is not empty, this function returns an impersonated
+   * GoogleCredentials instance. {@code sourceCredentials} should be the principal service account
+   * (SA). The last element in {@code targetServiceAccounts} will be used as the "target" account to
+   * impersonate. Any additional SAs in {@code targetServiceAccounts} will be used as delegates. The
+   * original {@code sourceCredentials} are returned if {@code targetServiceAccounts} is empty.
+   *
+   * @param sourceCredentials
+   * @param targetServiceAccounts
+   * @return GoogleCredentials
+   */
   private static GoogleCredentials impersonateServiceAccount(
       GoogleCredentials sourceCredentials, List<String> targetServiceAccounts) {
+    if (targetServiceAccounts.isEmpty()) {
+      return sourceCredentials;
+    }
 
     int lastIdx = targetServiceAccounts.size() - 1;
     String targetServiceAccount = targetServiceAccounts.get(lastIdx);

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -103,12 +103,11 @@ public class Oauth2Bigquery {
       HttpTransport httpTransport,
       String userAgent,
       String rootUrl,
-      String targetServiceAccount,
-      @Nullable String oauthToken,
-      List<String> delegates) {
+      List<String> targetServiceAccounts,
+      @Nullable String oauthToken) {
 
-    if (targetServiceAccount != null) {
-      credential = impersonateServiceAccount(credential, targetServiceAccount, delegates);
+    if (!targetServiceAccounts.isEmpty()) {
+      credential = impersonateServiceAccount(credential, targetServiceAccounts);
     }
 
     HttpRequestTimeoutInitializer httpRequestInitializer =
@@ -172,8 +171,7 @@ public class Oauth2Bigquery {
       Integer readTimeout,
       String rootUrl,
       HttpTransport httpTransport,
-      String targetServiceAccount,
-      List<String> delegates)
+      List<String> targetServiceAccounts)
       throws SQLException {
     GoogleCredentials credential = GoogleCredentials.create(new AccessToken(oauthToken, null));
 
@@ -187,9 +185,8 @@ public class Oauth2Bigquery {
             httpTransport,
             userAgent,
             rootUrl,
-            targetServiceAccount,
-            oauthToken,
-            delegates);
+            targetServiceAccounts,
+            oauthToken);
 
     return new MinifiedBigquery(bqBuilder);
   }
@@ -281,8 +278,7 @@ public class Oauth2Bigquery {
       Integer connectTimeout,
       String rootUrl,
       HttpTransport httpTransport,
-      String targetServiceAccount,
-      List<String> delegates)
+      List<String> targetServiceAccounts)
       throws GeneralSecurityException, IOException {
     GoogleCredentials credential =
         createServiceAccountCredential(
@@ -298,9 +294,8 @@ public class Oauth2Bigquery {
             httpTransport,
             userAgent,
             rootUrl,
-            targetServiceAccount,
-            null,
-            delegates);
+            targetServiceAccounts,
+            null);
 
     return new MinifiedBigquery(bqBuilder);
   }
@@ -335,8 +330,7 @@ public class Oauth2Bigquery {
       Integer readTimeout,
       String rootUrl,
       HttpTransport httpTransport,
-      String targetServiceAccount,
-      List<String> delegates)
+      List<String> targetServiceAccounts)
       throws IOException {
     GoogleCredentials credential = GoogleCredentials.getApplicationDefault();
 
@@ -350,9 +344,8 @@ public class Oauth2Bigquery {
             httpTransport,
             userAgent,
             rootUrl,
-            targetServiceAccount,
-            null,
-            delegates);
+            targetServiceAccounts,
+            null);
 
     return new MinifiedBigquery(bqBuilder);
   }
@@ -395,9 +388,11 @@ public class Oauth2Bigquery {
   }
 
   private static GoogleCredentials impersonateServiceAccount(
-      GoogleCredentials sourceCredentials,
-      String targetServiceAccount,
-      @Nullable List<String> delegates) {
+      GoogleCredentials sourceCredentials, List<String> targetServiceAccounts) {
+
+    int lastIdx = targetServiceAccounts.size() - 1;
+    String targetServiceAccount = targetServiceAccounts.get(lastIdx);
+    List<String> delegates = targetServiceAccounts.subList(0, lastIdx);
 
     return ImpersonatedCredentials.create(
         sourceCredentials,

--- a/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/Oauth2Bigquery.java
@@ -105,7 +105,7 @@ public class Oauth2Bigquery {
       String rootUrl,
       String targetServiceAccount,
       @Nullable String oauthToken,
-      @Nullable List<String> delegates) {
+      List<String> delegates) {
 
     if (targetServiceAccount != null) {
       credential = impersonateServiceAccount(credential, targetServiceAccount, delegates);

--- a/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/JdbcUrlTest.java
@@ -259,9 +259,9 @@ public class JdbcUrlTest {
             + testProps.getProperty("dataset");
     url +=
         "?withApplicationDefaultCredentials=true&targetServiceAccount="
-            + testProps.getProperty("limitedpermissiontargetaccount")
-            + "&delegates="
-            + testProps.getProperty("delegates");
+            + testProps.getProperty("delegates")
+            + ","
+            + testProps.getProperty("limitedpermissiontargetaccount");
     BQConnection bqConn = new BQConnection(url, new Properties());
     BQStatement stmt = new BQStatement(bqConn.getProjectId(), bqConn);
     // Don't really care about the results here, just need to be able to run a query
@@ -278,9 +278,9 @@ public class JdbcUrlTest {
             + testProps.getProperty("dataset");
     url +=
         "?withApplicationDefaultCredentials=true&targetServiceAccount="
-            + testProps.getProperty("limitedpermissiontargetaccount")
-            + "&delegates="
-            + testProps.getProperty("baddelegates");
+            + testProps.getProperty("baddelegates")
+            + ","
+            + testProps.getProperty("limitedpermissiontargetaccount");
     BQConnection bqConn = new BQConnection(url, new Properties());
     BQStatement stmt = new BQStatement(bqConn.getProjectId(), bqConn);
     try {

--- a/src/test/java/net/starschema/clouddb/jdbc/QueryResultTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/QueryResultTest.java
@@ -256,7 +256,8 @@ public class QueryResultTest {
       result = stmt.executeQuery(sql);
     } catch (SQLException e) {
       this.logger.debug("SQLexception" + e.toString());
-      Assert.assertTrue(e.toString().contains("Not found: Table guid754187384106:m_lab.2010_01"));
+      Assert.assertTrue(
+          e.toString().contains("Access Denied: Table guid754187384106:m_lab.2010_01"));
     }
   }
 

--- a/src/test/java/net/starschema/clouddb/jdbc/TimeoutTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/TimeoutTest.java
@@ -180,7 +180,8 @@ public class TimeoutTest {
     } catch (SQLException e) {
       this.logger.debug("SQLexception" + e.toString());
       // fail("SQLException" + e.toString());
-      Assert.assertTrue(e.toString().contains("Not found: Table guid754187384106:m_lab.2010_01"));
+      Assert.assertTrue(
+          e.toString().contains("Access Denied: Table guid754187384106:m_lab.2010_01"));
     }
   }
 


### PR DESCRIPTION
Adds support for [Service Account delegation](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-delegated) for impersonation. 

The `targetServiceAccount` param now accepts a comma separated list of SA emails (in order) to use as a delegation chain to access the "target" account.  The last SA will be used as the "target" account for impersonation.

For example `targetServiceAccount=<delegate-sa-1>,<delegate-sa-2>,<target-ccount>`

If a single SA is provided then it will simply be used as the impersonated account.