### PR TITLE
Mark assertj as a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.16.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This was added as a standard dependency rather than test dependency, correcting that here. 