### PR TITLE
Prevent setting projectId for sync queries twice

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -634,7 +634,7 @@ public class BQSupportFuncts {
       qr.setMaxResults(maxResults);
     }
 
-    return bigquery.jobs().query(querySql, qr).setProjectId(projectId).execute();
+    return bigquery.jobs().query(projectId, qr).execute();
   }
 
   /**


### PR DESCRIPTION
Looks like we were setting the `projectId` param to be the `querySql` and then overwriting it by calling `setProjectId`. We set the `querySql` while building the `QueryRequest` so we were just doing this incorrectly. Wasn't causing any problems but probably good to correct it.

