### PR TITLE
Prevent NPE if connection is closed before result set is initialized 

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSet.java
@@ -151,9 +151,12 @@ public class BQForwardOnlyResultSet implements java.sql.ResultSet {
       throws SQLException {
     logger.debug("Created forward only resultset TYPE_FORWARD_ONLY");
     this.Statementreference = (Statement) bqStatementRoot;
-    this.bigquery = bigquery;
     this.completedJob = completedJob;
     this.projectId = projectId;
+    if (bigquery == null) {
+      throw new BQSQLException("Failed to fetch results. Connection is closed.");
+    }
+    this.bigquery = bigquery;
 
     if (completedJob != null) {
       BiEngineStatistics biEngineStatistics =

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -667,9 +667,7 @@ public class BQForwardOnlyResultSetFunctionTest {
   @Test
   public void testBQForwardOnlyResultSetDoesntThrowNPE() throws Exception {
     BQConnection bq = conn();
-    BQStatement stmt =
-        new BQStatement(
-            defaultProjectId, bq, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+    BQStatement stmt = (BQStatement) bq.createStatement();
     QueryResponse qr = stmt.runSyncQuery("SELECT 1", false);
     Job ref =
         bq.getBigquery()


### PR DESCRIPTION
Edge case was causing a NPE to be thrown when initializing `BQForwardOnlyResultSet`. The underlying issue seems to be a race condition where a connection is closed after the job has been completed but _before_ the driver has an opportunity to get the query results. Specifically, calling `close()` on a `BQConnection` sets its `bigquery` attribute to `null` so efforts to `getQueryResultsDivided` would fail. 

This just adds an additional check to see if `bigquery` is null and throws a more informative exception. 