### PR TITLE
Check for empty jobs response when polling for query completion

### DIFF
--- a/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQStatement.java
@@ -264,9 +264,8 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
             throw new BQSQLException("Cannot poll results without a job reference");
           }
           try {
-            status =
-                BQSupportFuncts.getQueryState(
-                    referencedJob, this.connection.getBigquery(), projectId);
+            Job pollJob = getPollJob(referencedJob);
+            status = BQSupportFuncts.logAndGetQueryState(pollJob);
           } catch (IOException e) {
             if (retries++ < MAX_IO_FAILURE_RETRIES) {
               continue;
@@ -432,6 +431,12 @@ public class BQStatement extends BQStatementRoot implements java.sql.Statement {
   /** Wrap [BQSupportFuncts.cancelQuery] purely for testability purposes. */
   protected void performQueryCancel(JobReference jobRefToCancel) throws IOException {
     BQSupportFuncts.cancelQuery(jobRefToCancel, this.connection.getBigquery(), projectId);
+  }
+
+  /** Wrap [BQSupportFuncts.getPollJob] for convenience and testability purposes. */
+  protected Job getPollJob(Job jobToPoll) throws IOException {
+    JobReference jobRef = jobToPoll.getJobReference();
+    return BQSupportFuncts.getPollJob(jobRef, this.connection.getBigquery(), projectId);
   }
 
   /**

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -327,7 +327,7 @@ public class BQSupportFuncts {
     return queryResult;
   }
 
-  private static Job getPollJob(JobReference jobRef, Bigquery bq, String projectId)
+  public static Job getPollJob(JobReference jobRef, Bigquery bq, String projectId)
       throws IOException {
     return bq.jobs().get(projectId, jobRef.getJobId()).setLocation(jobRef.getLocation()).execute();
   }

--- a/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
+++ b/src/main/java/net/starschema/clouddb/jdbc/BQSupportFuncts.java
@@ -327,6 +327,11 @@ public class BQSupportFuncts {
     return queryResult;
   }
 
+  private static Job getPollJob(JobReference jobRef, Bigquery bq, String projectId)
+      throws IOException {
+    return bq.jobs().get(projectId, jobRef.getJobId()).setLocation(jobRef.getLocation()).execute();
+  }
+
   /**
    * Returns the status of a job
    *
@@ -340,12 +345,25 @@ public class BQSupportFuncts {
   public static String getQueryState(Job myjob, Bigquery bigquery, String projectId)
       throws IOException {
     JobReference myjobReference = myjob.getJobReference();
-    Job pollJob =
-        bigquery
-            .jobs()
-            .get(projectId, myjobReference.getJobId())
-            .setLocation(myjobReference.getLocation())
-            .execute();
+    Job pollJob = getPollJob(myjobReference, bigquery, projectId);
+    return logAndGetQueryState(pollJob);
+  }
+
+  /**
+   * Logs the status and running time of a job and returns its current state
+   *
+   * @param pollJob Instance of Job
+   * @return the status of the job
+   * @throws IOException
+   *     <p>if the request to get the job specified by myjob and projectId fails
+   */
+  public static String logAndGetQueryState(Job pollJob) throws IOException {
+    if (pollJob == null
+        || pollJob.isEmpty()
+        || pollJob.getStatus().isEmpty()
+        || pollJob.getStatistics().isEmpty()) {
+      throw new IOException("Failed to fetch query state.");
+    }
     BQSupportFuncts.logger.info(
         "Job status: "
             + pollJob.getStatus().getState()

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -23,6 +23,7 @@ package net.starschema.clouddb.jdbc;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.JobStatus;
 import com.google.api.services.bigquery.model.QueryResponse;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
@@ -683,6 +684,22 @@ public class BQForwardOnlyResultSetFunctionTest {
       Assert.fail("Initalizing BQForwardOnlyResultSet should throw something other than a NPE.");
     } catch (SQLException e) {
       Assert.assertEquals(e.getMessage(), "Failed to fetch results. Connection is closed.");
+    }
+  }
+
+  @Test
+  public void testPollingQueryStateHandlesNullResponse() throws Exception {
+    Job emptyJob = new Job();
+    Job emptyStatusJob = new Job().setStatus(new JobStatus());
+    Job[] jobs = new Job[] {emptyJob, emptyStatusJob};
+    for (Job j : jobs) {
+      try {
+        BQSupportFuncts.logAndGetQueryState(j);
+      } catch (NullPointerException e) {
+        Assert.fail("Should not have thrown a NPE");
+      } catch (IOException e) {
+        Assert.assertEquals(e.getMessage(), "Failed to fetch query state.");
+      }
     }
   }
 

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -688,22 +688,6 @@ public class BQForwardOnlyResultSetFunctionTest {
   }
 
   @Test
-  public void testPollingQueryStateHandlesNullResponse() throws Exception {
-    Job emptyJob = new Job();
-    Job emptyStatusJob = new Job().setStatus(new JobStatus());
-    Job[] jobs = new Job[] {emptyJob, emptyStatusJob};
-    for (Job j : jobs) {
-      try {
-        BQSupportFuncts.logAndGetQueryState(j);
-      } catch (NullPointerException e) {
-        Assert.fail("Should not have thrown a NPE");
-      } catch (IOException e) {
-        Assert.assertEquals(e.getMessage(), "Failed to fetch query state.");
-      }
-    }
-  }
-
-  @Test
   public void testHandlesAllNullResponseFields() throws Exception {
     try {
       mockResponse("{}");

--- a/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
+++ b/src/test/java/net/starschema/clouddb/jdbc/BQForwardOnlyResultSetFunctionTest.java
@@ -23,7 +23,6 @@ package net.starschema.clouddb.jdbc;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.services.bigquery.model.Job;
-import com.google.api.services.bigquery.model.JobStatus;
 import com.google.api.services.bigquery.model.QueryResponse;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;


### PR DESCRIPTION
A NPE could be thrown within `BQStatement.runSync` for long running queries. Doesn't happen often but if the BQ project has a reservation quota that's reached while polling for a query job to finish then check for its current state might return an incomplete `Job`. 

We now throw an `IOException` in that case which will at least retry the polling query rather than bubbling up a NPE.

